### PR TITLE
Make starting a drag less sensitive

### DIFF
--- a/src/controller/layoutController.js
+++ b/src/controller/layoutController.js
@@ -80,6 +80,11 @@ export class LayoutController {
   static dragTarget = null;
 
   /**
+   * @type {Number}
+   */
+  static dragDistance = 0;
+
+  /**
    * @type {?Component}
    */
   static selectedComponent = null;
@@ -1233,11 +1238,14 @@ export class LayoutController {
    */
   static onDragMove(event) {
     if (LayoutController.dragTarget) {
-      let a = event.getLocalPosition(LayoutController.dragTarget.parent);
       if (!LayoutController.dragTarget.isDragging) {
-        let diff = LayoutController.dragTarget.getPose().subtract(LayoutController.dragTarget.dragStartPos).subtract({ ...a, angle: 0 });
-        const distance = diff.magnitude();
-        if (distance <= 16.0) {
+        const diff = Math.sqrt(event.movementX * event.movementX + event.movementY * event.movementY);
+        LayoutController.dragDistance += diff;
+        let threshold = 8.0;
+        if (LayoutController.dragTarget.getUsedConnections().length > 0) {
+          threshold = 16.0;
+        }
+        if (LayoutController.dragDistance <= threshold) {
           return;
         }
         LayoutController.dragTarget.isDragging = true;
@@ -1247,6 +1255,7 @@ export class LayoutController {
           LayoutController.selectComponent(null);
         }
       }
+      let a = event.getLocalPosition(LayoutController.dragTarget.parent);
       a.x += LayoutController.dragTarget.dragStartPos.x;
       a.y += LayoutController.dragTarget.dragStartPos.y;
       // Snap to grid if enabled
@@ -1286,6 +1295,7 @@ export class LayoutController {
         }
       }
       LayoutController.dragTarget = null;
+      LayoutController.dragDistance = 0;
     } else {
       window.app.stage.off('pointermove', LayoutController.onPan);
       if (LayoutController.isPanning) {

--- a/src/controller/layoutController.js
+++ b/src/controller/layoutController.js
@@ -71,6 +71,20 @@ export { SerializedLayout };
 const CurrentFormatVersion = 2;
 export { CurrentFormatVersion };
 
+/**
+ * Drag thresholds for component movement.
+ * @type {Number}
+ * @constant
+ */
+const DRAG_THRESHOLD = 8.0;
+
+/**
+ * Drag threshold for movement of components with connections.
+ * @type {Number}
+ * @constant
+ */
+const DRAG_THRESHOLD_CONNECTION = 16.0;
+
 export class LayoutController {
   static _instance = null;
 
@@ -1241,9 +1255,9 @@ export class LayoutController {
       if (!LayoutController.dragTarget.isDragging) {
         const diff = Math.sqrt(event.movementX * event.movementX + event.movementY * event.movementY);
         LayoutController.dragDistance += diff;
-        let threshold = 8.0;
+        let threshold = DRAG_THRESHOLD;
         if (LayoutController.dragTarget.getUsedConnections().length > 0) {
-          threshold = 16.0;
+          threshold = DRAG_THRESHOLD_CONNECTION;
         }
         if (LayoutController.dragDistance <= threshold) {
           return;

--- a/src/model/component.js
+++ b/src/model/component.js
@@ -721,6 +721,7 @@ export class Component extends Container {
       return;
     }
     LayoutController.dragTarget = this;
+    LayoutController.dragDistance = 0;
     this.alpha = 0.5;
     this.isDragging = false;
     let a = e.getLocalPosition(this.parent);


### PR DESCRIPTION
Fixes https://bricklayouts.canny.io/feature-requests/p/click-drag-is-too-sensitive-sometimes