### PR TITLE
Add undo system using Command Pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 src/cloud
 spec/cloud
 .cloud-private
+.kiro/specs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ npm start            # starts local dev server
 CI=true npx jasmine-browser-runner runSpecs --config=spec/support/jasmine-browser.ci.mjs
 ```
 
-- ~874 specs, completes in ~6-9 seconds
+- ~902 specs, completes in ~6-9 seconds
 - A WebGL patch is applied during CI for PixiJS v8 headless Chrome support
 
 ## Code style

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ npm start            # starts local dev server
 CI=true npx jasmine-browser-runner runSpecs --config=spec/support/jasmine-browser.ci.mjs
 ```
 
-- ~851 specs, completes in ~6-9 seconds
+- ~874 specs, completes in ~6-9 seconds
 - A WebGL patch is applied during CI for PixiJS v8 headless Chrome support
 
 ## Code style
@@ -48,3 +48,14 @@ PixiJS v8 (rendering), Jasmine (testing), Tabulator (tables), RBush (spatial ind
 - Consider browser compatibility: desktop Chrome/Firefox/Safari/Edge, mobile Safari (iOS), mobile Chrome (iOS/Android)
 - The Visual Viewport API handles iOS Chrome rotation — see `layoutController.js` `initWindowEvents()`
 - API Gateway Cognito authorizer expects ID tokens, not access tokens
+
+## Undo system
+
+- `src/controller/undoManager.js` manages an undo buffer using the Command Pattern
+- `UNDO_BUFFER_SIZE` (module export, default 3) controls the buffer depth
+- When adding new operations that modify the layout (add/remove/edit components, modify layers), record an undo entry via `this.undoManager.record({ type, data })`
+- Undo entries store minimal inverse data, not full snapshots — each entry references components/layers by UUID
+- Use `suppress()`/`unsuppress()` around bulk automated operations (imports, resets) that should not be undoable
+- The `#isUndoing` flag automatically prevents re-recording during undo execution
+- Hotkey: Ctrl+Z / Cmd+Z (no redo)
+- No entries are recorded when `LayoutController.readOnly` is true

--- a/spec/support/layoutLayer.spec.mjs
+++ b/spec/support/layoutLayer.spec.mjs
@@ -887,4 +887,21 @@ describe("LayoutLayer", function() {
             layoutLayer.cleanupGroupDeserialization();
         });
     });
+
+    describe("findComponentByUuid", function() {
+        it("returns a component by UUID", function() {
+            let layoutLayer = new LayoutLayer();
+            let mockComponent = jasmine.createSpyObj('Component', ['destroy'], {
+                uuid: 'test-uuid-123'
+            });
+            Object.setPrototypeOf(mockComponent, Component.prototype);
+            layoutLayer.children.push(mockComponent);
+            expect(layoutLayer.findComponentByUuid('test-uuid-123')).toBe(mockComponent);
+        });
+
+        it("returns null for unknown UUID", function() {
+            let layoutLayer = new LayoutLayer();
+            expect(layoutLayer.findComponentByUuid('nonexistent')).toBeNull();
+        });
+    });
 });

--- a/spec/support/something.spec.mjs
+++ b/spec/support/something.spec.mjs
@@ -10521,4 +10521,35 @@ describe("LayoutController", function() {
             });
         });
     });
+    describe("UndoManager", function() {
+        it("correctly undoes zOrder changes", function() {
+            /** @type {LayoutController} */
+            let layoutController = window.layoutController;
+            layoutController.reset();
+            let trackData = layoutController.trackData.bundles[0].assets.find((a) => a.alias === "railStraight9V");
+            let baseplateData = layoutController.trackData.bundles[0].assets.find((a) => a.alias === "baseplate32x32");
+            layoutController.addComponent(baseplateData);
+            LayoutController.selectComponent();
+            layoutController.addComponent(trackData);
+            layoutController.addComponent(trackData);
+            let baseplate = layoutController.currentLayer.children[0];
+            let track1 = layoutController.currentLayer.children[1];
+            let track2 = layoutController.currentLayer.children[2];
+            expect(baseplate.baseData.alias).toBe("baseplate32x32");
+            expect(track1.baseData.alias).toBe("railStraight9V");
+            expect(track2.baseData.alias).toBe("railStraight9V");
+            expect(layoutController.currentLayer.children[0].uuid).toBe(baseplate.uuid);
+            expect(layoutController.currentLayer.children[1].uuid).toBe(track1.uuid);
+            expect(layoutController.currentLayer.children[2].uuid).toBe(track2.uuid);
+            layoutController.selectConnected();
+            layoutController.sendSelectedComponentToBack();
+            expect(layoutController.currentLayer.children[0].uuid).toBe(track1.uuid);
+            expect(layoutController.currentLayer.children[1].uuid).toBe(track2.uuid);
+            expect(layoutController.currentLayer.children[2].uuid).toBe(baseplate.uuid);
+            layoutController.undoManager.undo();
+            expect(layoutController.currentLayer.children[0].uuid).toBe(baseplate.uuid);
+            expect(layoutController.currentLayer.children[1].uuid).toBe(track1.uuid);
+            expect(layoutController.currentLayer.children[2].uuid).toBe(track2.uuid);
+        });
+    });
 });

--- a/spec/support/undoManager.spec.mjs
+++ b/spec/support/undoManager.spec.mjs
@@ -1,5 +1,6 @@
 import { UndoManager, UNDO_BUFFER_SIZE } from '../../src/controller/undoManager.js';
 import { Component } from '../../src/model/component.js';
+import { ComponentGroup } from '../../src/model/componentGroup.js';
 import { LayoutController } from '../../src/controller/layoutController.js';
 import { LayoutLayer } from '../../src/model/layoutLayer.js';
 
@@ -179,18 +180,85 @@ describe('UndoManager', () => {
     });
 
     it('sets group back to temporary for undo-group', () => {
-      const mockGroup = { uuid: 'g1', isTemporary: false };
+      const mockGroup = { uuid: 'g1', isTemporary: false, group: null };
+      const mockComp = { uuid: 'c1', group: mockGroup };
       const mockLayer = {
-        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.returnValue(mockGroup)
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.callFake(uuid => {
+          if (uuid === 'c1') return mockComp;
+          return null;
+        })
       };
       mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
 
       undoManager.record({
         type: 'group',
-        data: { groupUuid: 'g1', layerUuid: '456' }
+        data: { groupUuid: 'g1', layerUuid: '456', memberComponentUuid: 'c1' }
       });
       undoManager.undo();
       expect(mockGroup.isTemporary).toBe(true);
+    });
+
+    it('finds group through nested group chain for undo-group', () => {
+      const outerGroup = { uuid: 'outer', isTemporary: false, group: null };
+      const innerGroup = { uuid: 'inner', group: outerGroup };
+      const mockComp = { uuid: 'c1', group: innerGroup };
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.callFake(uuid => {
+          if (uuid === 'c1') return mockComp;
+          return null;
+        })
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+
+      undoManager.record({
+        type: 'group',
+        data: { groupUuid: 'outer', layerUuid: '456', memberComponentUuid: 'c1' }
+      });
+      undoManager.undo();
+      expect(outerGroup.isTemporary).toBe(true);
+    });
+
+    it('restores group to permanent for undo-ungroup when group still exists', () => {
+      const mockGroup = { uuid: 'g1', isTemporary: true, group: null };
+      const mockComp = { uuid: 'c1', group: mockGroup };
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.callFake(uuid => {
+          if (uuid === 'c1') return mockComp;
+          return null;
+        })
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+
+      undoManager.record({
+        type: 'ungroup',
+        data: { groupUuid: 'g1', layerUuid: '456', componentUuids: ['c1', 'c2'] }
+      });
+      undoManager.undo();
+      expect(mockGroup.isTemporary).toBe(false);
+    });
+
+    it('recreates group from component UUIDs for undo-ungroup when group was destroyed', () => {
+      const mockCompA = { uuid: 'a', group: null, parent: 'layer', connections: new Map() };
+      const mockCompB = { uuid: 'b', group: null, parent: 'layer', connections: new Map() };
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.callFake(uuid => {
+          if (uuid === 'a') return mockCompA;
+          if (uuid === 'b') return mockCompB;
+          return null;
+        })
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+
+      undoManager.record({
+        type: 'ungroup',
+        data: { groupUuid: 'g1', layerUuid: '456', componentUuids: ['a', 'b'] }
+      });
+      undoManager.undo();
+      expect(LayoutController.selectComponent).toHaveBeenCalled();
+      const selectedGroup = LayoutController.selectComponent.calls.mostRecent().args[0];
+      expect(selectedGroup).toBeInstanceOf(ComponentGroup);
+      expect(selectedGroup.isTemporary).toBe(false);
+      expect(selectedGroup.components.length).toBe(2);
     });
 
     it('restores layer name and opacity for undo-layer_edit', () => {

--- a/spec/support/undoManager.spec.mjs
+++ b/spec/support/undoManager.spec.mjs
@@ -119,6 +119,146 @@ describe('UndoManager', () => {
       expect(mockController.deleteComponent).toHaveBeenCalledWith(mockComp);
     });
 
+    it('destroys permanent group for undo-duplicate_group', () => {
+      const mockGroup = {
+        uuid: 'g1',
+        isTemporary: false,
+        group: null,
+        destroyed: false,
+        destroy: jasmine.createSpy('destroy').and.callFake(function () { this.destroyed = true; }),
+        getAllComponents: () => [mockCompA, mockCompB]
+      };
+      const mockCompA = { uuid: 'a', group: mockGroup, destroyed: false };
+      const mockCompB = { uuid: 'b', group: mockGroup, destroyed: false };
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.callFake(uuid => {
+          if (uuid === 'a') return mockCompA;
+          if (uuid === 'b') return mockCompB;
+          return null;
+        })
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+
+      undoManager.record({
+        type: 'duplicate_group',
+        data: { componentUuids: ['a', 'b'], layerUuid: '456' }
+      });
+      undoManager.undo();
+      expect(mockGroup.destroy).toHaveBeenCalledTimes(1);
+    });
+
+    it('deletes orphaned components for undo-duplicate_group when temp group was destroyed', () => {
+      const mockCompA = { uuid: 'a', group: null, destroyed: false };
+      const mockCompB = { uuid: 'b', group: null, destroyed: false };
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.callFake(uuid => {
+          if (uuid === 'a') return mockCompA;
+          if (uuid === 'b') return mockCompB;
+          return null;
+        })
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+
+      undoManager.record({
+        type: 'duplicate_group',
+        data: { componentUuids: ['a', 'b'], layerUuid: '456' }
+      });
+      undoManager.undo();
+      expect(mockController.deleteComponent).toHaveBeenCalledWith(mockCompA);
+      expect(mockController.deleteComponent).toHaveBeenCalledWith(mockCompB);
+    });
+
+    it('destroys temp group and deletes its components for undo-duplicate_group', () => {
+      const mockCompA = { uuid: 'a', group: null, destroyed: false };
+      const mockCompB = { uuid: 'b', group: null, destroyed: false };
+      const mockGroup = {
+        uuid: 'g1',
+        isTemporary: true,
+        group: null,
+        destroyed: false,
+        destroy: jasmine.createSpy('destroy').and.callFake(function () {
+          this.destroyed = true;
+          mockCompA.group = null;
+          mockCompB.group = null;
+        }),
+        getAllComponents: () => [mockCompA, mockCompB]
+      };
+      mockCompA.group = mockGroup;
+      mockCompB.group = mockGroup;
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.callFake(uuid => {
+          if (uuid === 'a') return mockCompA;
+          if (uuid === 'b') return mockCompB;
+          return null;
+        })
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+
+      undoManager.record({
+        type: 'duplicate_group',
+        data: { componentUuids: ['a', 'b'], layerUuid: '456' }
+      });
+      undoManager.undo();
+      expect(mockGroup.destroy).toHaveBeenCalledTimes(1);
+      expect(mockController.deleteComponent).toHaveBeenCalledWith(mockCompA);
+      expect(mockController.deleteComponent).toHaveBeenCalledWith(mockCompB);
+    });
+
+    it('deselects group before destroying for undo-duplicate_group', () => {
+      const mockGroup = {
+        uuid: 'g1',
+        isTemporary: false,
+        group: null,
+        destroyed: false,
+        destroy: jasmine.createSpy('destroy').and.callFake(function () { this.destroyed = true; }),
+        getAllComponents: () => [mockCompA]
+      };
+      const mockCompA = { uuid: 'a', group: mockGroup, destroyed: false };
+      LayoutController.selectedComponent = mockGroup;
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.callFake(uuid => {
+          if (uuid === 'a') return mockCompA;
+          return null;
+        })
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+
+      undoManager.record({
+        type: 'duplicate_group',
+        data: { componentUuids: ['a'], layerUuid: '456' }
+      });
+      undoManager.undo();
+      expect(LayoutController.selectComponent).toHaveBeenCalledWith(null);
+      expect(mockGroup.destroy).toHaveBeenCalled();
+    });
+
+    it('traverses to top-level group for undo-duplicate_group with nested groups', () => {
+      const outerGroup = {
+        uuid: 'outer',
+        isTemporary: false,
+        group: null,
+        destroyed: false,
+        destroy: jasmine.createSpy('destroy').and.callFake(function () { this.destroyed = true; }),
+        getAllComponents: () => [mockComp]
+      };
+      const innerGroup = { uuid: 'inner', group: outerGroup };
+      const mockComp = { uuid: 'c1', group: innerGroup, destroyed: false };
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.callFake(uuid => {
+          if (uuid === 'c1') return mockComp;
+          return null;
+        })
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+
+      undoManager.record({
+        type: 'duplicate_group',
+        data: { componentUuids: ['c1'], layerUuid: '456' }
+      });
+      undoManager.undo();
+      expect(outerGroup.destroy).toHaveBeenCalledTimes(1);
+    });
+
     it('restores position for undo-move', () => {
       const mockComp = {
         uuid: '123',

--- a/spec/support/undoManager.spec.mjs
+++ b/spec/support/undoManager.spec.mjs
@@ -567,7 +567,7 @@ describe('UndoManager', () => {
       expect(mockLayer.setChildIndex).toHaveBeenCalledWith(mockCompB, 3);
     });
 
-    it('restores group components in ascending index order for undo-zorder_group', () => {
+    it('restores group components in descending index order for undo-zorder_group', () => {
       const mockCompA = { uuid: 'a' };
       const mockCompB = { uuid: 'b' };
       const callOrder = [];
@@ -595,7 +595,7 @@ describe('UndoManager', () => {
         }
       });
       undoManager.undo();
-      expect(callOrder).toEqual(['a', 'b']);
+      expect(callOrder).toEqual(['b', 'a']);
     });
 
     it('clamps indices to layer bounds for undo-zorder_group', () => {

--- a/spec/support/undoManager.spec.mjs
+++ b/spec/support/undoManager.spec.mjs
@@ -538,6 +538,86 @@ describe('UndoManager', () => {
       expect(mockLayer.setChildIndex).toHaveBeenCalledWith(mockComp, 1);
     });
 
+    it('restores child indices for all components in undo-zorder_group', () => {
+      const mockCompA = { uuid: 'a' };
+      const mockCompB = { uuid: 'b' };
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.callFake(uuid => {
+          if (uuid === 'a') return mockCompA;
+          if (uuid === 'b') return mockCompB;
+          return null;
+        }),
+        children: [{}, {}, mockCompA, mockCompB, {}, {}],
+        setChildIndex: jasmine.createSpy('setChildIndex')
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+
+      undoManager.record({
+        type: 'zorder_group',
+        data: {
+          layerUuid: '456',
+          components: [
+            { componentUuid: 'a', previousIndex: 1 },
+            { componentUuid: 'b', previousIndex: 3 }
+          ]
+        }
+      });
+      undoManager.undo();
+      expect(mockLayer.setChildIndex).toHaveBeenCalledWith(mockCompA, 1);
+      expect(mockLayer.setChildIndex).toHaveBeenCalledWith(mockCompB, 3);
+    });
+
+    it('restores group components in ascending index order for undo-zorder_group', () => {
+      const mockCompA = { uuid: 'a' };
+      const mockCompB = { uuid: 'b' };
+      const callOrder = [];
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.callFake(uuid => {
+          if (uuid === 'a') return mockCompA;
+          if (uuid === 'b') return mockCompB;
+          return null;
+        }),
+        children: [{}, {}, mockCompA, mockCompB, {}, {}],
+        setChildIndex: jasmine.createSpy('setChildIndex').and.callFake((comp, idx) => {
+          callOrder.push(comp.uuid);
+        })
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+
+      undoManager.record({
+        type: 'zorder_group',
+        data: {
+          layerUuid: '456',
+          components: [
+            { componentUuid: 'b', previousIndex: 5 },
+            { componentUuid: 'a', previousIndex: 2 }
+          ]
+        }
+      });
+      undoManager.undo();
+      expect(callOrder).toEqual(['a', 'b']);
+    });
+
+    it('clamps indices to layer bounds for undo-zorder_group', () => {
+      const mockComp = { uuid: 'a' };
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.returnValue(mockComp),
+        children: [mockComp, {}],
+        setChildIndex: jasmine.createSpy('setChildIndex')
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+
+      undoManager.record({
+        type: 'zorder_group',
+        data: {
+          layerUuid: '456',
+          components: [{ componentUuid: 'a', previousIndex: 99 }]
+        }
+      });
+      undoManager.undo();
+      expect(mockLayer.setChildIndex).toHaveBeenCalledWith(mockComp, 1);
+    });
+
     it('sets group back to temporary for undo-group', () => {
       const mockGroup = { uuid: 'g1', isTemporary: false, group: null };
       const mockComp = { uuid: 'c1', group: mockGroup };

--- a/spec/support/undoManager.spec.mjs
+++ b/spec/support/undoManager.spec.mjs
@@ -904,6 +904,7 @@ describe('UndoManager', () => {
       comp.sprite = { rotation: 0 };
       comp.deleteCollisionTree = jasmine.createSpy('deleteCollisionTree');
       comp.insertCollisionTree = jasmine.createSpy('insertCollisionTree');
+      comp.closeConnections = jasmine.createSpy('closeConnections');
       comp.connections = [];
       components.set('orig', comp);
 

--- a/spec/support/undoManager.spec.mjs
+++ b/spec/support/undoManager.spec.mjs
@@ -1,0 +1,477 @@
+import { UndoManager, UNDO_BUFFER_SIZE } from '../../src/controller/undoManager.js';
+import { Component } from '../../src/model/component.js';
+import { LayoutController } from '../../src/controller/layoutController.js';
+
+describe('UndoManager', () => {
+  let undoManager;
+  let mockController;
+
+  beforeEach(() => {
+    LayoutController.selectedComponent = null;
+    spyOn(LayoutController, 'selectComponent');
+    mockController = {
+      readOnly: false,
+      layers: [],
+      workspace: {
+        removeChild: jasmine.createSpy('removeChild'),
+        addChildAt: jasmine.createSpy('addChildAt'),
+        setChildIndex: jasmine.createSpy('setChildIndex')
+      },
+      trackData: {
+        bundles: [{ assets: [] }]
+      },
+      findComponentByUuid: jasmine.createSpy('findComponentByUuid'),
+      findLayerByUuid: jasmine.createSpy('findLayerByUuid'),
+      deleteComponent: jasmine.createSpy('deleteComponent'),
+      updateLayerList: jasmine.createSpy('updateLayerList'),
+      _positionSelectionToolbar: jasmine.createSpy('_positionSelectionToolbar'),
+      _showSelectionToolbar: jasmine.createSpy('_showSelectionToolbar')
+    };
+    undoManager = new UndoManager(mockController);
+  });
+
+  describe('record', () => {
+    it('adds an entry to the stack', () => {
+      undoManager.record({ type: 'add', data: { componentUuid: '123', layerUuid: '456' } });
+      expect(undoManager.length).toBe(1);
+    });
+
+    it('evicts oldest entry when buffer exceeds UNDO_BUFFER_SIZE', () => {
+      for (let i = 0; i < UNDO_BUFFER_SIZE + 2; i++) {
+        undoManager.record({ type: 'add', data: { componentUuid: `id-${i}`, layerUuid: '456' } });
+      }
+      expect(undoManager.length).toBe(UNDO_BUFFER_SIZE);
+    });
+
+    it('is a no-op when readOnly is true', () => {
+      mockController.readOnly = true;
+      undoManager.record({ type: 'add', data: { componentUuid: '123', layerUuid: '456' } });
+      expect(undoManager.length).toBe(0);
+    });
+
+    it('is a no-op when suppressed', () => {
+      undoManager.suppress();
+      undoManager.record({ type: 'add', data: { componentUuid: '123', layerUuid: '456' } });
+      expect(undoManager.length).toBe(0);
+    });
+
+    it('resumes recording after unsuppress', () => {
+      undoManager.suppress();
+      undoManager.record({ type: 'add', data: { componentUuid: '123', layerUuid: '456' } });
+      undoManager.unsuppress();
+      undoManager.record({ type: 'add', data: { componentUuid: '456', layerUuid: '789' } });
+      expect(undoManager.length).toBe(1);
+    });
+  });
+
+  describe('clear', () => {
+    it('empties the stack', () => {
+      undoManager.record({ type: 'add', data: { componentUuid: '123', layerUuid: '456' } });
+      undoManager.record({ type: 'add', data: { componentUuid: '456', layerUuid: '789' } });
+      undoManager.clear();
+      expect(undoManager.length).toBe(0);
+    });
+  });
+
+  describe('undo', () => {
+    it('is a no-op when stack is empty', () => {
+      expect(() => undoManager.undo()).not.toThrow();
+    });
+
+    it('does not record new entries during undo execution', () => {
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.returnValue({ uuid: '123' }),
+        children: []
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+      mockController.deleteComponent = jasmine.createSpy('deleteComponent').and.callFake(() => {
+        undoManager.record({ type: 'add', data: { componentUuid: 'nested', layerUuid: '456' } });
+      });
+
+      undoManager.record({ type: 'add', data: { componentUuid: '123', layerUuid: '456' } });
+      undoManager.undo();
+      expect(undoManager.length).toBe(0);
+    });
+
+    it('calls deleteComponent for undo-add', () => {
+      const mockComp = { uuid: '123' };
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.returnValue(mockComp)
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+
+      undoManager.record({ type: 'add', data: { componentUuid: '123', layerUuid: '456' } });
+      undoManager.undo();
+      expect(mockController.deleteComponent).toHaveBeenCalledWith(mockComp);
+    });
+
+    it('calls deleteComponent for undo-duplicate', () => {
+      const mockComp = { uuid: '123' };
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.returnValue(mockComp)
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+
+      undoManager.record({ type: 'duplicate', data: { componentUuid: '123', layerUuid: '456' } });
+      undoManager.undo();
+      expect(mockController.deleteComponent).toHaveBeenCalledWith(mockComp);
+    });
+
+    it('restores position for undo-move', () => {
+      const mockComp = {
+        uuid: '123',
+        position: { set: jasmine.createSpy('set') },
+        sprite: { rotation: 0 },
+        deleteCollisionTree: jasmine.createSpy('deleteCollisionTree'),
+        insertCollisionTree: jasmine.createSpy('insertCollisionTree'),
+        closeConnections: jasmine.createSpy('closeConnections'),
+        getOpenConnections: jasmine.createSpy('getOpenConnections').and.returnValue([])
+      };
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.returnValue(mockComp),
+        findMatchingConnection: jasmine.createSpy('findMatchingConnection')
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+
+      undoManager.record({
+        type: 'move',
+        data: { componentUuid: '123', layerUuid: '456', previousPose: { x: 10, y: 20, angle: 0.5 } }
+      });
+      undoManager.undo();
+      expect(mockComp.deleteCollisionTree).toHaveBeenCalled();
+      expect(mockComp.closeConnections).toHaveBeenCalled();
+      expect(mockComp.position.set).toHaveBeenCalledWith(10, 20);
+      expect(mockComp.sprite.rotation).toBe(0.5);
+      expect(mockComp.insertCollisionTree).toHaveBeenCalled();
+    });
+
+    it('restores locked state for undo-lock', () => {
+      const mockComp = { uuid: '123', locked: true };
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.returnValue(mockComp)
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+
+      undoManager.record({
+        type: 'lock',
+        data: { componentUuid: '123', layerUuid: '456', wasLocked: false }
+      });
+      undoManager.undo();
+      expect(mockComp.locked).toBe(false);
+    });
+
+    it('restores child index for undo-zorder', () => {
+      const mockComp = { uuid: '123' };
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.returnValue(mockComp),
+        children: [mockComp, {}, {}],
+        setChildIndex: jasmine.createSpy('setChildIndex')
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+
+      undoManager.record({
+        type: 'zorder',
+        data: { componentUuid: '123', layerUuid: '456', previousIndex: 1 }
+      });
+      undoManager.undo();
+      expect(mockLayer.setChildIndex).toHaveBeenCalledWith(mockComp, 1);
+    });
+
+    it('sets group back to temporary for undo-group', () => {
+      const mockGroup = { uuid: 'g1', isTemporary: false };
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.returnValue(mockGroup)
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+
+      undoManager.record({
+        type: 'group',
+        data: { groupUuid: 'g1', layerUuid: '456' }
+      });
+      undoManager.undo();
+      expect(mockGroup.isTemporary).toBe(true);
+    });
+
+    it('restores layer name and opacity for undo-layer_edit', () => {
+      const mockLayer = {
+        uuid: 'l1',
+        label: 'New Name',
+        alpha: 0.5
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+
+      undoManager.record({
+        type: 'layer_edit',
+        data: { layerUuid: 'l1', previousName: 'Old Name', previousOpacity: 1.0 }
+      });
+      undoManager.undo();
+      expect(mockLayer.label).toBe('Old Name');
+      expect(mockLayer.alpha).toBe(1.0);
+      expect(mockController.updateLayerList).toHaveBeenCalled();
+    });
+
+    it('handles undo when layer not found gracefully', () => {
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(null);
+      undoManager.record({ type: 'add', data: { componentUuid: '123', layerUuid: 'missing' } });
+      expect(() => undoManager.undo()).not.toThrow();
+    });
+
+    it('handles undo when component not found gracefully', () => {
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.returnValue(null)
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+      undoManager.record({ type: 'add', data: { componentUuid: 'missing', layerUuid: '456' } });
+      expect(() => undoManager.undo()).not.toThrow();
+    });
+
+    it('pops entries in LIFO order', () => {
+      const mockComp1 = { uuid: '1' };
+      const mockComp2 = { uuid: '2' };
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.callFake(uuid => {
+          if (uuid === '1') return mockComp1;
+          if (uuid === '2') return mockComp2;
+          return null;
+        })
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+
+      undoManager.record({ type: 'add', data: { componentUuid: '1', layerUuid: '456' } });
+      undoManager.record({ type: 'add', data: { componentUuid: '2', layerUuid: '456' } });
+      undoManager.undo();
+      expect(mockController.deleteComponent).toHaveBeenCalledWith(mockComp2);
+    });
+  });
+
+  describe('suppress/unsuppress', () => {
+    it('prevents recording when suppressed', () => {
+      undoManager.suppress();
+      undoManager.record({ type: 'add', data: { componentUuid: '123', layerUuid: '456' } });
+      undoManager.record({ type: 'add', data: { componentUuid: '456', layerUuid: '789' } });
+      undoManager.unsuppress();
+      expect(undoManager.length).toBe(0);
+    });
+
+    it('supports nested suppression', () => {
+      undoManager.suppress();
+      undoManager.suppress();
+      undoManager.unsuppress();
+      undoManager.record({ type: 'add', data: { componentUuid: '123', layerUuid: '456' } });
+      expect(undoManager.length).toBe(0);
+      undoManager.unsuppress();
+      undoManager.record({ type: 'add', data: { componentUuid: '456', layerUuid: '789' } });
+      expect(undoManager.length).toBe(1);
+    });
+
+    it('does not go below zero depth on extra unsuppress calls', () => {
+      undoManager.unsuppress();
+      undoManager.record({ type: 'add', data: { componentUuid: '123', layerUuid: '456' } });
+      expect(undoManager.length).toBe(1);
+    });
+  });
+
+  describe('component UUID update after recreate', () => {
+    let components;
+    let mockLayer;
+    let deserializeCount;
+
+    beforeEach(() => {
+      components = new Map();
+      deserializeCount = 0;
+
+      spyOn(Component, 'deserialize').and.callFake(() => {
+        deserializeCount++;
+        const newUuid = `restored-${deserializeCount}`;
+        const newComp = makeMockComp(newUuid);
+        components.set(newUuid, newComp);
+        return newComp;
+      });
+
+      mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid')
+          .and.callFake(uuid => components.get(uuid) || null),
+        addChild: jasmine.createSpy('addChild'),
+        children: [{}, {}],
+        setChildIndex: jasmine.createSpy('setChildIndex'),
+        findMatchingConnection: jasmine.createSpy('findMatchingConnection')
+      };
+
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid')
+        .and.returnValue(mockLayer);
+    });
+
+    function makeMockComp(uuid) {
+      return {
+        uuid,
+        baseData: { alias: 'test-track' },
+        destroy: jasmine.createSpy('destroy').and.callFake(() => {
+          components.delete(uuid);
+        }),
+        getOpenConnections: jasmine.createSpy('getOpenConnections').and.returnValue([])
+      };
+    }
+
+    it('updates remaining stack entries when undo-rotate recreates a component', () => {
+      const comp = makeMockComp('orig');
+      components.set('orig', comp);
+
+      undoManager.record({
+        type: 'rotate',
+        data: {
+          componentUuid: 'orig', layerUuid: 'l1',
+          previousPose: { x: 0, y: 0, angle: 0 },
+          previousState: { pose: {} }, childIndex: 0
+        }
+      });
+      undoManager.record({
+        type: 'rotate',
+        data: {
+          componentUuid: 'orig', layerUuid: 'l1',
+          previousPose: { x: 0, y: 0, angle: 0.5 },
+          previousState: { pose: {} }, childIndex: 0
+        }
+      });
+
+      undoManager.undo();
+      expect(Component.deserialize).toHaveBeenCalledTimes(1);
+
+      undoManager.undo();
+      expect(Component.deserialize).toHaveBeenCalledTimes(2);
+      expect(undoManager.length).toBe(0);
+    });
+
+    it('updates remaining stack entries when undo-edit recreates a component', () => {
+      const comp = makeMockComp('orig');
+      components.set('orig', comp);
+
+      undoManager.record({
+        type: 'edit',
+        data: {
+          componentUuid: 'orig', layerUuid: 'l1',
+          previousState: { pose: {} }, childIndex: 0
+        }
+      });
+      undoManager.record({
+        type: 'edit',
+        data: {
+          componentUuid: 'orig', layerUuid: 'l1',
+          previousState: { pose: {} }, childIndex: 0
+        }
+      });
+
+      undoManager.undo();
+      expect(Component.deserialize).toHaveBeenCalledTimes(1);
+
+      undoManager.undo();
+      expect(Component.deserialize).toHaveBeenCalledTimes(2);
+      expect(undoManager.length).toBe(0);
+    });
+
+    it('does not update UUIDs when undo-rotate uses the simple pose path', () => {
+      const comp = makeMockComp('orig');
+      comp.position = { set: jasmine.createSpy('set') };
+      comp.sprite = { rotation: 0 };
+      comp.deleteCollisionTree = jasmine.createSpy('deleteCollisionTree');
+      comp.insertCollisionTree = jasmine.createSpy('insertCollisionTree');
+      comp.connections = [];
+      components.set('orig', comp);
+
+      undoManager.record({
+        type: 'rotate',
+        data: {
+          componentUuid: 'orig', layerUuid: 'l1',
+          previousPose: { x: 0, y: 0, angle: 0 },
+          previousState: null, childIndex: -1
+        }
+      });
+      undoManager.record({
+        type: 'rotate',
+        data: {
+          componentUuid: 'orig', layerUuid: 'l1',
+          previousPose: { x: 1, y: 2, angle: 0.5 },
+          previousState: null, childIndex: -1
+        }
+      });
+
+      undoManager.undo();
+      expect(Component.deserialize).not.toHaveBeenCalled();
+
+      undoManager.undo();
+      expect(Component.deserialize).not.toHaveBeenCalled();
+      expect(undoManager.length).toBe(0);
+    });
+
+    it('updates UUIDs across mixed entry types for the same component', () => {
+      const comp = makeMockComp('orig');
+      components.set('orig', comp);
+
+      undoManager.record({
+        type: 'rotate',
+        data: {
+          componentUuid: 'orig', layerUuid: 'l1',
+          previousPose: { x: 0, y: 0, angle: 0 },
+          previousState: { pose: {} }, childIndex: 0
+        }
+      });
+      undoManager.record({
+        type: 'edit',
+        data: {
+          componentUuid: 'orig', layerUuid: 'l1',
+          previousState: { pose: {} }, childIndex: 0
+        }
+      });
+
+      undoManager.undo();
+      expect(Component.deserialize).toHaveBeenCalledTimes(1);
+
+      undoManager.undo();
+      expect(Component.deserialize).toHaveBeenCalledTimes(2);
+      expect(undoManager.length).toBe(0);
+    });
+
+    it('consecutive rotations with 1 connection can be undone 3 times', () => {
+      const comp = makeMockComp('orig');
+      components.set('orig', comp);
+
+      undoManager.record({
+        type: 'rotate',
+        data: {
+          componentUuid: 'orig', layerUuid: 'l1',
+          previousPose: { x: 0, y: 0, angle: 0 },
+          previousState: { pose: {} }, childIndex: 0
+        }
+      });
+      undoManager.record({
+        type: 'rotate',
+        data: {
+          componentUuid: 'orig', layerUuid: 'l1',
+          previousPose: { x: 5, y: 10, angle: 0.5 },
+          previousState: { pose: {} }, childIndex: 0
+        }
+      });
+      undoManager.record({
+        type: 'rotate',
+        data: {
+          componentUuid: 'orig', layerUuid: 'l1',
+          previousPose: { x: 10, y: 20, angle: 1.0 },
+          previousState: { pose: {} }, childIndex: 0
+        }
+      });
+
+      expect(undoManager.length).toBe(3);
+
+      undoManager.undo();
+      expect(Component.deserialize).toHaveBeenCalledTimes(1);
+      expect(undoManager.length).toBe(2);
+
+      undoManager.undo();
+      expect(Component.deserialize).toHaveBeenCalledTimes(2);
+      expect(undoManager.length).toBe(1);
+
+      undoManager.undo();
+      expect(Component.deserialize).toHaveBeenCalledTimes(3);
+      expect(undoManager.length).toBe(0);
+    });
+  });
+});

--- a/spec/support/undoManager.spec.mjs
+++ b/spec/support/undoManager.spec.mjs
@@ -1,6 +1,7 @@
 import { UndoManager, UNDO_BUFFER_SIZE } from '../../src/controller/undoManager.js';
 import { Component } from '../../src/model/component.js';
 import { LayoutController } from '../../src/controller/layoutController.js';
+import { LayoutLayer } from '../../src/model/layoutLayer.js';
 
 describe('UndoManager', () => {
   let undoManager;
@@ -241,6 +242,44 @@ describe('UndoManager', () => {
       undoManager.record({ type: 'add', data: { componentUuid: '2', layerUuid: '456' } });
       undoManager.undo();
       expect(mockController.deleteComponent).toHaveBeenCalledWith(mockComp2);
+    });
+
+    it('restores a deleted layer using deserialize and cleanupGroupDeserialization', () => {
+      const serializedLayer = {
+        name: 'Test Layer',
+        visible: false,
+        opacity: 75,
+        components: [
+          { type: 'straight', pose: { x: 0, y: 0, angle: 0 }, connections: [] }
+        ],
+        groups: [{ uuid: 'g1', components: ['c1', 'c2'] }]
+      };
+
+      const mockBaseData = { alias: 'straight' };
+      const mockComp = {
+        uuid: 'c1',
+        getOpenConnections: jasmine.createSpy('getOpenConnections').and.returnValue([])
+      };
+
+      spyOn(LayoutLayer.prototype, 'deserialize').and.stub();
+      spyOn(LayoutLayer.prototype, 'addChild').and.stub();
+      spyOn(LayoutLayer.prototype, 'cleanupGroupDeserialization').and.stub();
+      spyOn(Component, 'deserialize').and.returnValue(mockComp);
+
+      mockController.trackData = { bundles: [{ assets: [mockBaseData] }] };
+      mockController.layers = [{}];
+
+      undoManager.record({
+        type: 'layer_delete',
+        data: { layerUuid: 'l1', layerIndex: 1, serializedLayer }
+      });
+      undoManager.undo();
+
+      expect(LayoutLayer.prototype.deserialize).toHaveBeenCalledWith(serializedLayer);
+      expect(Component.deserialize).toHaveBeenCalledTimes(1);
+      expect(LayoutLayer.prototype.cleanupGroupDeserialization).toHaveBeenCalled();
+      expect(mockController.layers.length).toBe(2);
+      expect(mockController.updateLayerList).toHaveBeenCalled();
     });
   });
 

--- a/spec/support/undoManager.spec.mjs
+++ b/spec/support/undoManager.spec.mjs
@@ -162,6 +162,80 @@ describe('UndoManager', () => {
       expect(mockComp.locked).toBe(false);
     });
 
+    it('restores locked state on a permanent group for undo-lock_perm_group', () => {
+      const mockGroup = { uuid: 'g1', locked: true, group: null };
+      const mockComp = { uuid: 'c1', group: mockGroup };
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.callFake(uuid => {
+          if (uuid === 'c1') return mockComp;
+          return null;
+        })
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+
+      undoManager.record({
+        type: 'lock_perm_group',
+        data: { groupUuid: 'g1', layerUuid: '456', memberComponentUuid: 'c1', wasLocked: false }
+      });
+      undoManager.undo();
+      expect(mockGroup.locked).toBe(false);
+    });
+
+    it('restores locked state on individual components for undo-lock_temp_group', () => {
+      const mockCompA = { uuid: 'a', locked: true };
+      const mockCompB = { uuid: 'b', locked: true };
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.callFake(uuid => {
+          if (uuid === 'a') return mockCompA;
+          if (uuid === 'b') return mockCompB;
+          return null;
+        })
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+
+      undoManager.record({
+        type: 'lock_temp_group',
+        data: {
+          layerUuid: '456',
+          members: [
+            { type: 'component', componentUuid: 'a', wasLocked: false },
+            { type: 'component', componentUuid: 'b', wasLocked: true }
+          ]
+        }
+      });
+      undoManager.undo();
+      expect(mockCompA.locked).toBe(false);
+      expect(mockCompB.locked).toBe(true);
+    });
+
+    it('restores locked state on nested permanent group for undo-lock_temp_group', () => {
+      const nestedGroup = { uuid: 'ng1', locked: true, group: null };
+      const nestedComp = { uuid: 'nc1', group: nestedGroup };
+      const mockCompA = { uuid: 'a', locked: true };
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.callFake(uuid => {
+          if (uuid === 'a') return mockCompA;
+          if (uuid === 'nc1') return nestedComp;
+          return null;
+        })
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+
+      undoManager.record({
+        type: 'lock_temp_group',
+        data: {
+          layerUuid: '456',
+          members: [
+            { type: 'component', componentUuid: 'a', wasLocked: false },
+            { type: 'group', memberComponentUuid: 'nc1', groupUuid: 'ng1', wasLocked: false }
+          ]
+        }
+      });
+      undoManager.undo();
+      expect(mockCompA.locked).toBe(false);
+      expect(nestedGroup.locked).toBe(false);
+    });
+
     it('restores child index for undo-zorder', () => {
       const mockComp = { uuid: '123' };
       const mockLayer = {

--- a/spec/support/undoManager.spec.mjs
+++ b/spec/support/undoManager.spec.mjs
@@ -480,6 +480,210 @@ describe('UndoManager', () => {
       expect(selectedGroup.components.length).toBe(2);
     });
 
+    it('restores a deleted permanent group with components via undo-delete_group', () => {
+      const mockBaseData = { alias: 'straight' };
+      const mockComp = {
+        uuid: 'c1',
+        group: null,
+        getOpenConnections: jasmine.createSpy('getOpenConnections').and.returnValue([])
+      };
+      spyOn(Component, 'deserialize').and.returnValue(mockComp);
+      const mockLayer = {
+        children: [{}, {}],
+        addChild: jasmine.createSpy('addChild'),
+        setChildIndex: jasmine.createSpy('setChildIndex'),
+        findMatchingConnection: jasmine.createSpy('findMatchingConnection'),
+        _reconstructGroups: jasmine.createSpy('_reconstructGroups'),
+        getGroupLookupMap: jasmine.createSpy('getGroupLookupMap').and.callFake(() => {
+          const topGroup = new ComponentGroup(false);
+          topGroup.uuid = 'g1';
+          topGroup.parent = mockLayer;
+          return new Map([['g1', topGroup]]);
+        }),
+        cleanupGroupDeserialization: jasmine.createSpy('cleanupGroupDeserialization')
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+      mockController.trackData = { bundles: [{ assets: [mockBaseData] }] };
+
+      undoManager.record({
+        type: 'delete_group',
+        data: {
+          layerUuid: 'l1',
+          temporary: false,
+          parentGroupUuid: null,
+          components: [
+            { baseDataAlias: 'straight', serialized: { pose: {} }, childIndex: 1 }
+          ],
+          groups: [{ uuid: 'g1' }]
+        }
+      });
+      undoManager.undo();
+      expect(mockLayer._reconstructGroups).toHaveBeenCalledWith([{ uuid: 'g1' }]);
+      expect(Component.deserialize).toHaveBeenCalledTimes(1);
+      expect(mockLayer.addChild).toHaveBeenCalledWith(mockComp);
+      expect(LayoutController.selectComponent).toHaveBeenCalled();
+      const selected = LayoutController.selectComponent.calls.mostRecent().args[0];
+      expect(selected).toBeInstanceOf(ComponentGroup);
+      expect(selected.isTemporary).toBe(false);
+    });
+
+    it('restores a deleted temporary group and marks it temporary via undo-delete_group', () => {
+      const mockBaseData = { alias: 'curve' };
+      const mockComp = {
+        uuid: 'c1',
+        group: null,
+        getOpenConnections: jasmine.createSpy('getOpenConnections').and.returnValue([])
+      };
+      spyOn(Component, 'deserialize').and.returnValue(mockComp);
+      const mockLayer = {
+        children: [],
+        addChild: jasmine.createSpy('addChild'),
+        setChildIndex: jasmine.createSpy('setChildIndex'),
+        findMatchingConnection: jasmine.createSpy('findMatchingConnection'),
+        _reconstructGroups: jasmine.createSpy('_reconstructGroups'),
+        getGroupLookupMap: jasmine.createSpy('getGroupLookupMap').and.callFake(() => {
+          const topGroup = new ComponentGroup(false);
+          topGroup.uuid = 'g2';
+          topGroup.parent = mockLayer;
+          return new Map([['g2', topGroup]]);
+        }),
+        cleanupGroupDeserialization: jasmine.createSpy('cleanupGroupDeserialization')
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+      mockController.trackData = { bundles: [{ assets: [mockBaseData] }] };
+
+      undoManager.record({
+        type: 'delete_group',
+        data: {
+          layerUuid: 'l1',
+          temporary: true,
+          parentGroupUuid: null,
+          components: [
+            { baseDataAlias: 'curve', serialized: { pose: {} }, childIndex: 0 }
+          ],
+          groups: [{ uuid: 'g2' }]
+        }
+      });
+      undoManager.undo();
+      const selected = LayoutController.selectComponent.calls.mostRecent().args[0];
+      expect(selected).toBeInstanceOf(ComponentGroup);
+      expect(selected.isTemporary).toBe(true);
+    });
+
+    it('restores a deleted group with nested groups and multiple components via undo-delete_group', () => {
+      const mockBaseData1 = { alias: 'straight' };
+      const mockBaseData2 = { alias: 'curve' };
+      let deserializeCount = 0;
+      const mockComps = [];
+      spyOn(Component, 'deserialize').and.callFake(() => {
+        const comp = {
+          uuid: `c${deserializeCount}`,
+          group: null,
+          getOpenConnections: jasmine.createSpy('getOpenConnections').and.returnValue([])
+        };
+        deserializeCount++;
+        mockComps.push(comp);
+        return comp;
+      });
+      const mockLayer = {
+        children: [{}, {}, {}],
+        addChild: jasmine.createSpy('addChild'),
+        setChildIndex: jasmine.createSpy('setChildIndex'),
+        findMatchingConnection: jasmine.createSpy('findMatchingConnection'),
+        _reconstructGroups: jasmine.createSpy('_reconstructGroups'),
+        getGroupLookupMap: jasmine.createSpy('getGroupLookupMap').and.callFake(() => {
+          const outerGroup = new ComponentGroup(false);
+          outerGroup.uuid = 'outer';
+          outerGroup.parent = mockLayer;
+          const innerGroup = new ComponentGroup(false);
+          innerGroup.uuid = 'inner';
+          innerGroup.parent = mockLayer;
+          innerGroup.group = outerGroup;
+          return new Map([['outer', outerGroup], ['inner', innerGroup]]);
+        }),
+        cleanupGroupDeserialization: jasmine.createSpy('cleanupGroupDeserialization')
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+      mockController.trackData = { bundles: [{ assets: [mockBaseData1, mockBaseData2] }] };
+
+      undoManager.record({
+        type: 'delete_group',
+        data: {
+          layerUuid: 'l1',
+          temporary: false,
+          parentGroupUuid: null,
+          components: [
+            { baseDataAlias: 'straight', serialized: { pose: {}, group: 'outer' }, childIndex: 0 },
+            { baseDataAlias: 'curve', serialized: { pose: {}, group: 'inner' }, childIndex: 2 },
+            { baseDataAlias: 'straight', serialized: { pose: {}, group: 'inner' }, childIndex: 1 }
+          ],
+          groups: [
+            { uuid: 'outer' },
+            { uuid: 'inner', group: 'outer', locked: 1 }
+          ]
+        }
+      });
+      undoManager.undo();
+      expect(mockLayer._reconstructGroups).toHaveBeenCalledWith([
+        { uuid: 'outer' },
+        { uuid: 'inner', group: 'outer', locked: 1 }
+      ]);
+      expect(Component.deserialize).toHaveBeenCalledTimes(3);
+      expect(mockLayer.addChild).toHaveBeenCalledTimes(3);
+      const selected = LayoutController.selectComponent.calls.mostRecent().args[0];
+      expect(selected).toBeInstanceOf(ComponentGroup);
+      expect(selected.uuid).toBe('outer');
+    });
+
+    it('restores z-ordering when undoing a group delete', () => {
+      const mockBaseData = { alias: 'straight' };
+      const mockComps = [];
+      spyOn(Component, 'deserialize').and.callFake(() => {
+        const comp = {
+          uuid: `c${mockComps.length}`,
+          group: null,
+          getOpenConnections: jasmine.createSpy('getOpenConnections').and.returnValue([])
+        };
+        mockComps.push(comp);
+        return comp;
+      });
+      const mockLayer = {
+        children: [{}, {}, {}, {}, {}],
+        addChild: jasmine.createSpy('addChild').and.callFake(() => {
+          mockLayer.children.push({});
+        }),
+        setChildIndex: jasmine.createSpy('setChildIndex'),
+        findMatchingConnection: jasmine.createSpy('findMatchingConnection'),
+        _reconstructGroups: jasmine.createSpy('_reconstructGroups'),
+        getGroupLookupMap: jasmine.createSpy('getGroupLookupMap').and.callFake(() => {
+          const group = new ComponentGroup(false);
+          group.uuid = 'g1';
+          group.parent = mockLayer;
+          return new Map([['g1', group]]);
+        }),
+        cleanupGroupDeserialization: jasmine.createSpy('cleanupGroupDeserialization')
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+      mockController.trackData = { bundles: [{ assets: [mockBaseData] }] };
+
+      undoManager.record({
+        type: 'delete_group',
+        data: {
+          layerUuid: 'l1',
+          temporary: false,
+          parentGroupUuid: null,
+          components: [
+            { baseDataAlias: 'straight', serialized: { pose: {} }, childIndex: 1 },
+            { baseDataAlias: 'straight', serialized: { pose: {} }, childIndex: 3 }
+          ],
+          groups: [{ uuid: 'g1' }]
+        }
+      });
+      undoManager.undo();
+      expect(mockLayer.setChildIndex).toHaveBeenCalledWith(mockComps[0], 1);
+      expect(mockLayer.setChildIndex).toHaveBeenCalledWith(mockComps[1], 3);
+    });
+
     it('restores layer name and opacity for undo-layer_edit', () => {
       const mockLayer = {
         uuid: 'l1',

--- a/spec/support/undoManager.spec.mjs
+++ b/spec/support/undoManager.spec.mjs
@@ -147,6 +147,151 @@ describe('UndoManager', () => {
       expect(mockComp.insertCollisionTree).toHaveBeenCalled();
     });
 
+    it('restores positions of all components for undo-move_group', () => {
+      const mockCompA = {
+        uuid: 'a',
+        position: { set: jasmine.createSpy('set') },
+        sprite: { rotation: 0 },
+        deleteCollisionTree: jasmine.createSpy('deleteCollisionTree'),
+        insertCollisionTree: jasmine.createSpy('insertCollisionTree'),
+        closeConnections: jasmine.createSpy('closeConnections'),
+        getOpenConnections: jasmine.createSpy('getOpenConnections').and.returnValue([])
+      };
+      const mockCompB = {
+        uuid: 'b',
+        position: { set: jasmine.createSpy('set') },
+        sprite: { rotation: 0.3 },
+        deleteCollisionTree: jasmine.createSpy('deleteCollisionTree'),
+        insertCollisionTree: jasmine.createSpy('insertCollisionTree'),
+        closeConnections: jasmine.createSpy('closeConnections'),
+        getOpenConnections: jasmine.createSpy('getOpenConnections').and.returnValue([])
+      };
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.callFake(uuid => {
+          if (uuid === 'a') return mockCompA;
+          if (uuid === 'b') return mockCompB;
+          return null;
+        }),
+        findMatchingConnection: jasmine.createSpy('findMatchingConnection')
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+
+      undoManager.record({
+        type: 'move_group',
+        data: {
+          layerUuid: '456',
+          components: [
+            { componentUuid: 'a', previousPose: { x: 10, y: 20, angle: 0 } },
+            { componentUuid: 'b', previousPose: { x: 30, y: 40, angle: 0.5 } }
+          ]
+        }
+      });
+      undoManager.undo();
+      expect(mockCompA.deleteCollisionTree).toHaveBeenCalled();
+      expect(mockCompA.closeConnections).toHaveBeenCalled();
+      expect(mockCompA.position.set).toHaveBeenCalledWith(10, 20);
+      expect(mockCompA.sprite.rotation).toBe(0);
+      expect(mockCompA.insertCollisionTree).toHaveBeenCalled();
+      expect(mockCompB.position.set).toHaveBeenCalledWith(30, 40);
+      expect(mockCompB.sprite.rotation).toBe(0.5);
+    });
+
+    it('restores connections after all positions are set for undo-move_group', () => {
+      const openConA = { uuid: 'oc-a' };
+      const openConB = { uuid: 'oc-b' };
+      const mockCompA = {
+        uuid: 'a',
+        position: { set: jasmine.createSpy('set') },
+        sprite: { rotation: 0 },
+        deleteCollisionTree: jasmine.createSpy('deleteCollisionTree'),
+        insertCollisionTree: jasmine.createSpy('insertCollisionTree'),
+        closeConnections: jasmine.createSpy('closeConnections'),
+        getOpenConnections: jasmine.createSpy('getOpenConnections').and.returnValue([openConA])
+      };
+      const mockCompB = {
+        uuid: 'b',
+        position: { set: jasmine.createSpy('set') },
+        sprite: { rotation: 0 },
+        deleteCollisionTree: jasmine.createSpy('deleteCollisionTree'),
+        insertCollisionTree: jasmine.createSpy('insertCollisionTree'),
+        closeConnections: jasmine.createSpy('closeConnections'),
+        getOpenConnections: jasmine.createSpy('getOpenConnections').and.returnValue([openConB])
+      };
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.callFake(uuid => {
+          if (uuid === 'a') return mockCompA;
+          if (uuid === 'b') return mockCompB;
+          return null;
+        }),
+        findMatchingConnection: jasmine.createSpy('findMatchingConnection')
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+
+      undoManager.record({
+        type: 'move_group',
+        data: {
+          layerUuid: '456',
+          components: [
+            { componentUuid: 'a', previousPose: { x: 0, y: 0, angle: 0 } },
+            { componentUuid: 'b', previousPose: { x: 5, y: 5, angle: 0 } }
+          ]
+        }
+      });
+      undoManager.undo();
+      expect(mockLayer.findMatchingConnection).toHaveBeenCalledWith(openConA, true);
+      expect(mockLayer.findMatchingConnection).toHaveBeenCalledWith(openConB, true);
+    });
+
+    it('restores positions and rotations for undo-rotate_group', () => {
+      const mockConnA = { uuid: 'conn-a', updateCircle: jasmine.createSpy('updateCircle') };
+      const mockCompA = {
+        uuid: 'a',
+        position: { set: jasmine.createSpy('set') },
+        sprite: { rotation: 0.5 },
+        deleteCollisionTree: jasmine.createSpy('deleteCollisionTree'),
+        insertCollisionTree: jasmine.createSpy('insertCollisionTree'),
+        closeConnections: jasmine.createSpy('closeConnections'),
+        connections: new Map([['conn-a', mockConnA]]),
+        getOpenConnections: jasmine.createSpy('getOpenConnections').and.returnValue([])
+      };
+      const mockCompB = {
+        uuid: 'b',
+        position: { set: jasmine.createSpy('set') },
+        sprite: { rotation: 1.2 },
+        deleteCollisionTree: jasmine.createSpy('deleteCollisionTree'),
+        insertCollisionTree: jasmine.createSpy('insertCollisionTree'),
+        closeConnections: jasmine.createSpy('closeConnections'),
+        connections: new Map(),
+        getOpenConnections: jasmine.createSpy('getOpenConnections').and.returnValue([])
+      };
+      const mockLayer = {
+        findComponentByUuid: jasmine.createSpy('findComponentByUuid').and.callFake(uuid => {
+          if (uuid === 'a') return mockCompA;
+          if (uuid === 'b') return mockCompB;
+          return null;
+        }),
+        findMatchingConnection: jasmine.createSpy('findMatchingConnection')
+      };
+      mockController.findLayerByUuid = jasmine.createSpy('findLayerByUuid').and.returnValue(mockLayer);
+
+      undoManager.record({
+        type: 'rotate_group',
+        data: {
+          layerUuid: '456',
+          components: [
+            { componentUuid: 'a', previousPose: { x: 10, y: 20, angle: 0 } },
+            { componentUuid: 'b', previousPose: { x: 30, y: 40, angle: 0.5 } }
+          ]
+        }
+      });
+      undoManager.undo();
+      expect(mockCompA.position.set).toHaveBeenCalledWith(10, 20);
+      expect(mockCompA.sprite.rotation).toBe(0);
+      expect(mockCompB.position.set).toHaveBeenCalledWith(30, 40);
+      expect(mockCompB.sprite.rotation).toBe(0.5);
+      expect(mockConnA.updateCircle).toHaveBeenCalled();
+    });
+
     it('restores locked state for undo-lock', () => {
       const mockComp = { uuid: '123', locked: true };
       const mockLayer = {
@@ -653,6 +798,46 @@ describe('UndoManager', () => {
       undoManager.undo();
       expect(Component.deserialize).toHaveBeenCalledTimes(3);
       expect(undoManager.length).toBe(0);
+    });
+
+    it('updates componentUuid inside move_group entries when a component is recreated', () => {
+      const comp = makeMockComp('orig');
+      comp.position = { set: jasmine.createSpy('set') };
+      comp.sprite = { rotation: 0 };
+      comp.deleteCollisionTree = jasmine.createSpy('deleteCollisionTree');
+      comp.insertCollisionTree = jasmine.createSpy('insertCollisionTree');
+      comp.closeConnections = jasmine.createSpy('closeConnections');
+      components.set('orig', comp);
+
+      undoManager.record({
+        type: 'move_group',
+        data: {
+          layerUuid: 'l1',
+          components: [
+            { componentUuid: 'orig', previousPose: { x: 0, y: 0, angle: 0 } }
+          ]
+        }
+      });
+      undoManager.record({
+        type: 'edit',
+        data: {
+          componentUuid: 'orig', layerUuid: 'l1',
+          previousState: { pose: {} }, childIndex: 0
+        }
+      });
+
+      undoManager.undo();
+      expect(Component.deserialize).toHaveBeenCalledTimes(1);
+
+      const restoredComp = components.get('restored-1');
+      restoredComp.position = { set: jasmine.createSpy('set') };
+      restoredComp.sprite = { rotation: 0 };
+      restoredComp.deleteCollisionTree = jasmine.createSpy('deleteCollisionTree');
+      restoredComp.insertCollisionTree = jasmine.createSpy('insertCollisionTree');
+      restoredComp.closeConnections = jasmine.createSpy('closeConnections');
+
+      undoManager.undo();
+      expect(restoredComp.position.set).toHaveBeenCalledWith(0, 0);
     });
   });
 });

--- a/src/controller/layoutController.js
+++ b/src/controller/layoutController.js
@@ -3128,10 +3128,30 @@ export class LayoutController {
     }
     const comp = LayoutController.selectedComponent;
     const layer = comp.layer || comp.parent;
-    this.undoManager.record({
-      type: 'lock',
-      data: { componentUuid: comp.uuid, layerUuid: layer?.uuid, wasLocked: false }
-    });
+    if (comp instanceof ComponentGroup) {
+      if (comp.isTemporary) {
+        const members = comp.components.map(child => {
+          if (child instanceof ComponentGroup) {
+            return { type: 'group', memberComponentUuid: child.getAllComponents()[0]?.uuid, groupUuid: child.uuid, wasLocked: child.locked };
+          }
+          return { type: 'component', componentUuid: child.uuid, wasLocked: child.locked };
+        });
+        this.undoManager.record({
+          type: 'lock_temp_group',
+          data: { layerUuid: layer?.uuid, members }
+        });
+      } else {
+        this.undoManager.record({
+          type: 'lock_perm_group',
+          data: { groupUuid: comp.uuid, layerUuid: layer?.uuid, memberComponentUuid: comp.getAllComponents()[0]?.uuid, wasLocked: false }
+        });
+      }
+    } else {
+      this.undoManager.record({
+        type: 'lock',
+        data: { componentUuid: comp.uuid, layerUuid: layer?.uuid, wasLocked: false }
+      });
+    }
     comp.locked = true;
     this._showSelectionToolbar();
     this._positionSelectionToolbar();
@@ -3147,10 +3167,30 @@ export class LayoutController {
     }
     const comp = LayoutController.selectedComponent;
     const layer = comp.layer || comp.parent;
-    this.undoManager.record({
-      type: 'lock',
-      data: { componentUuid: comp.uuid, layerUuid: layer?.uuid, wasLocked: true }
-    });
+    if (comp instanceof ComponentGroup) {
+      if (comp.isTemporary) {
+        const members = comp.components.map(child => {
+          if (child instanceof ComponentGroup) {
+            return { type: 'group', memberComponentUuid: child.getAllComponents()[0]?.uuid, groupUuid: child.uuid, wasLocked: child.locked };
+          }
+          return { type: 'component', componentUuid: child.uuid, wasLocked: child.locked };
+        });
+        this.undoManager.record({
+          type: 'lock_temp_group',
+          data: { layerUuid: layer?.uuid, members }
+        });
+      } else {
+        this.undoManager.record({
+          type: 'lock_perm_group',
+          data: { groupUuid: comp.uuid, layerUuid: layer?.uuid, memberComponentUuid: comp.getAllComponents()[0]?.uuid, wasLocked: true }
+        });
+      }
+    } else {
+      this.undoManager.record({
+        type: 'lock',
+        data: { componentUuid: comp.uuid, layerUuid: layer?.uuid, wasLocked: true }
+      });
+    }
     comp.locked = false;
     this._showSelectionToolbar();
     this._positionSelectionToolbar();

--- a/src/controller/layoutController.js
+++ b/src/controller/layoutController.js
@@ -145,6 +145,11 @@ export class LayoutController {
   static preDragPose = null;
 
   /**
+   * @type {?Array<{componentUuid: String, previousPose: {x: Number, y: Number, angle: Number}}>}
+   */
+  static preDragComponentPoses = null;
+
+  /**
    * @type {?Component | ComponentGroup}
    */
   static selectedComponent = null;
@@ -2696,6 +2701,12 @@ export class LayoutController {
 
         if (!LayoutController.dragWithAlt) {
           LayoutController.preDragPose = LayoutController.dragTarget.getPose().serialize();
+          if (LayoutController.dragTarget instanceof ComponentGroup) {
+            LayoutController.preDragComponentPoses = LayoutController.dragTarget.getAllComponents().map(c => ({
+              componentUuid: c.uuid,
+              previousPose: c.getPose().serialize()
+            }));
+          }
         }
         LayoutController.dragTarget.isDragging = true;
         LayoutController.getInstance()._hideSelectionToolbar();
@@ -2772,22 +2783,34 @@ export class LayoutController {
         });
         LayoutController.dragIsNewComponent = null;
         LayoutController.preDragPose = null;
+        LayoutController.preDragComponentPoses = null;
       } else if (LayoutController.preDragPose) {
         const currentPose = target.getPose().serialize();
         if (currentPose.x !== LayoutController.preDragPose.x ||
             currentPose.y !== LayoutController.preDragPose.y ||
             currentPose.angle !== LayoutController.preDragPose.angle) {
           const layer = target.layer || target.parent;
-          LayoutController.getInstance().undoManager.record({
-            type: 'move',
-            data: {
-              componentUuid: target.uuid,
-              layerUuid: layer?.uuid,
-              previousPose: LayoutController.preDragPose
-            }
-          });
+          if (LayoutController.preDragComponentPoses) {
+            LayoutController.getInstance().undoManager.record({
+              type: 'move_group',
+              data: {
+                layerUuid: layer?.uuid,
+                components: LayoutController.preDragComponentPoses
+              }
+            });
+          } else {
+            LayoutController.getInstance().undoManager.record({
+              type: 'move',
+              data: {
+                componentUuid: target.uuid,
+                layerUuid: layer?.uuid,
+                previousPose: LayoutController.preDragPose
+              }
+            });
+          }
         }
         LayoutController.preDragPose = null;
+        LayoutController.preDragComponentPoses = null;
       }
       LayoutController.dragTarget = null;
       LayoutController.dragDistance = 0;
@@ -3106,15 +3129,27 @@ export class LayoutController {
     }
     const comp = LayoutController.selectedComponent;
     const layer = comp.layer || comp.parent;
-    const usedConnections = comp.getUsedConnections();
-    const previousPose = comp.getPose().serialize();
-    const previousState = usedConnections.length === 1 ? comp.serialize() : null;
-    const childIndex = usedConnections.length === 1 ? layer.children.indexOf(comp) : -1;
-    comp.rotate();
-    this.undoManager.record({
-      type: 'rotate',
-      data: { componentUuid: comp.uuid, layerUuid: layer?.uuid, previousPose, previousState, childIndex }
-    });
+    if (comp instanceof ComponentGroup) {
+      const componentPoses = comp.getAllComponents().map(c => ({
+        componentUuid: c.uuid,
+        previousPose: c.getPose().serialize()
+      }));
+      comp.rotate();
+      this.undoManager.record({
+        type: 'rotate_group',
+        data: { layerUuid: layer?.uuid, components: componentPoses }
+      });
+    } else {
+      const usedConnections = comp.getUsedConnections();
+      const previousPose = comp.getPose().serialize();
+      const previousState = usedConnections.length === 1 ? comp.serialize() : null;
+      const childIndex = usedConnections.length === 1 ? layer.children.indexOf(comp) : -1;
+      comp.rotate();
+      this.undoManager.record({
+        type: 'rotate',
+        data: { componentUuid: comp.uuid, layerUuid: layer?.uuid, previousPose, previousState, childIndex }
+      });
+    }
     this._positionSelectionToolbar();
   }
 

--- a/src/controller/layoutController.js
+++ b/src/controller/layoutController.js
@@ -2777,10 +2777,17 @@ export class LayoutController {
       LayoutController.finalizeDraggedComponent(target);
       if (LayoutController.dragIsNewComponent) {
         const layer = target.layer || target.parent;
-        LayoutController.getInstance().undoManager.record({
-          type: LayoutController.dragIsNewComponent,
-          data: { componentUuid: target.uuid, layerUuid: layer?.uuid }
-        });
+        if (target instanceof ComponentGroup) {
+          LayoutController.getInstance().undoManager.record({
+            type: 'duplicate_group',
+            data: { componentUuids: target.getAllComponents().map(c => c.uuid), layerUuid: layer?.uuid }
+          });
+        } else {
+          LayoutController.getInstance().undoManager.record({
+            type: LayoutController.dragIsNewComponent,
+            data: { componentUuid: target.uuid, layerUuid: layer?.uuid }
+          });
+        }
         LayoutController.dragIsNewComponent = null;
         LayoutController.preDragPose = null;
         LayoutController.preDragComponentPoses = null;
@@ -3120,10 +3127,17 @@ export class LayoutController {
         this.currentLayer.findMatchingConnection(openCon, true);
       });
     }
-    this.undoManager.record({
-      type: 'duplicate',
-      data: { componentUuid: clone.uuid, layerUuid: this.currentLayer.uuid }
-    });
+    if (clone instanceof ComponentGroup) {
+      this.undoManager.record({
+        type: 'duplicate_group',
+        data: { componentUuids: clone.getAllComponents().map(c => c.uuid), layerUuid: this.currentLayer.uuid }
+      });
+    } else {
+      this.undoManager.record({
+        type: 'duplicate',
+        data: { componentUuid: clone.uuid, layerUuid: this.currentLayer.uuid }
+      });
+    }
     LayoutController.selectComponent(clone);
   }
 

--- a/src/controller/layoutController.js
+++ b/src/controller/layoutController.js
@@ -2961,16 +2961,24 @@ export class LayoutController {
         return;
       }
       const comp = LayoutController.selectedComponent;
-      const previousIndex = this.currentLayer.children.indexOf(comp);
       if (comp instanceof Component) {
+        const previousIndex = this.currentLayer.children.indexOf(comp);
         this.currentLayer.setChildIndex(comp, this.currentLayer.children.length - 2);
+        this.undoManager.record({
+          type: 'zorder',
+          data: { componentUuid: comp.uuid, layerUuid: this.currentLayer.uuid, previousIndex }
+        });
       } else if (comp instanceof ComponentGroup) {
+        const components = comp.getAllComponents().map(c => ({
+          componentUuid: c.uuid,
+          previousIndex: this.currentLayer.children.indexOf(c)
+        }));
         comp.bringToFront();
+        this.undoManager.record({
+          type: 'zorder_group',
+          data: { layerUuid: this.currentLayer.uuid, components }
+        });
       }
-      this.undoManager.record({
-        type: 'zorder',
-        data: { componentUuid: comp.uuid, layerUuid: this.currentLayer.uuid, previousIndex }
-      });
     }
   }
 
@@ -2981,16 +2989,24 @@ export class LayoutController {
         return;
       }
       const comp = LayoutController.selectedComponent;
-      const previousIndex = this.currentLayer.children.indexOf(comp);
       if (comp instanceof Component) {
+        const previousIndex = this.currentLayer.children.indexOf(comp);
         this.currentLayer.setChildIndex(comp, 0);
+        this.undoManager.record({
+          type: 'zorder',
+          data: { componentUuid: comp.uuid, layerUuid: this.currentLayer.uuid, previousIndex }
+        });
       } else if (comp instanceof ComponentGroup) {
+        const components = comp.getAllComponents().map(c => ({
+          componentUuid: c.uuid,
+          previousIndex: this.currentLayer.children.indexOf(c)
+        }));
         comp.sendToBack();
+        this.undoManager.record({
+          type: 'zorder_group',
+          data: { layerUuid: this.currentLayer.uuid, components }
+        });
       }
-      this.undoManager.record({
-        type: 'zorder',
-        data: { componentUuid: comp.uuid, layerUuid: this.currentLayer.uuid, previousIndex }
-      });
     }
   }
 

--- a/src/controller/layoutController.js
+++ b/src/controller/layoutController.js
@@ -3169,9 +3169,14 @@ export class LayoutController {
       return;
     }
     const layer = selected.layer || selected.parent;
+    const allComponents = selected.getAllComponents();
     this.undoManager.record({
       type: 'group',
-      data: { groupUuid: selected.uuid, layerUuid: layer?.uuid }
+      data: {
+        groupUuid: selected.uuid,
+        layerUuid: layer?.uuid,
+        memberComponentUuid: allComponents[0]?.uuid
+      }
     });
     selected.isTemporary = false;
     this._showSelectionToolbar();
@@ -3187,9 +3192,19 @@ export class LayoutController {
       return;
     }
     const layer = selected.layer || selected.parent;
+    const componentUuids = selected.components.map(child => {
+      if (child instanceof ComponentGroup) {
+        return child.getAllComponents()[0]?.uuid;
+      }
+      return child.uuid;
+    }).filter(Boolean);
     this.undoManager.record({
       type: 'ungroup',
-      data: { groupUuid: selected.uuid, layerUuid: layer?.uuid }
+      data: {
+        groupUuid: selected.uuid,
+        layerUuid: layer?.uuid,
+        componentUuids
+      }
     });
     selected.isTemporary = true;
     this._showSelectionToolbar();

--- a/src/controller/layoutController.js
+++ b/src/controller/layoutController.js
@@ -3574,20 +3574,12 @@ export class LayoutController {
     console.log(`Delete Layer ${index}`);
     if (this.layers.length > 1) {
       let tempLayer = this.layers[index];
-      const serializedComponents = [];
-      for (const child of tempLayer.children) {
-        if (child instanceof Component) {
-          serializedComponents.push(child.serialize());
-        }
-      }
       this.undoManager.record({
         type: 'layer_delete',
         data: {
           layerUuid: tempLayer.uuid,
-          layerName: tempLayer.label,
-          layerOpacity: tempLayer.alpha,
           layerIndex: index,
-          serializedComponents
+          serializedLayer: tempLayer.serialize()
         }
       });
       this.layers.splice(index, 1);

--- a/src/controller/layoutController.js
+++ b/src/controller/layoutController.js
@@ -3018,6 +3018,10 @@ export class LayoutController {
     }
     const layer = component.layer || component.parent;
     const layerUuid = layer?.uuid;
+    if (component instanceof ComponentGroup) {
+      this.#deleteComponentGroup(component, layer, layerUuid);
+      return;
+    }
     const childIndex = layer ? layer.children.indexOf(component) : -1;
     const serialized = component.serialize();
     const baseDataAlias = component.baseData.alias;
@@ -3028,15 +3032,51 @@ export class LayoutController {
     if (this.copiedComponent === component) {
       this.copiedComponent = null;
     }
-    if (component instanceof ComponentGroup && component.isTemporary) {
-      component.isTemporary = false;
-    }
     component.destroy();
     this.undoManager.record({
       type: 'delete',
       data: { serialized, baseDataAlias, childIndex, layerUuid }
     });
     component = null;
+  }
+
+  #deleteComponentGroup(component, layer, layerUuid) {
+    const wasTemporary = component.isTemporary;
+    if (wasTemporary) {
+      component.isTemporary = false;
+    }
+    const allComponents = component.getAllComponents();
+    const components = allComponents.map(comp => ({
+      baseDataAlias: comp.baseData.alias,
+      serialized: comp.serialize(),
+      childIndex: layer ? layer.children.indexOf(comp) : -1
+    }));
+    const groups = [];
+    const collectGroups = (group) => {
+      groups.push(group.serialize());
+      for (const child of group.components) {
+        if (child instanceof ComponentGroup) {
+          collectGroups(child);
+        }
+      }
+    };
+    collectGroups(component);
+    const parentGroupUuid = groups[0].group || null;
+    delete groups[0].group;
+    if (LayoutController.selectedComponent === component) {
+      LayoutController.selectedComponent = null;
+      this._hideSelectionToolbar();
+    }
+    if (this.copiedComponent === component) {
+      this.copiedComponent = null;
+    }
+    this.undoManager.suppress();
+    component.destroy();
+    this.undoManager.unsuppress();
+    this.undoManager.record({
+      type: 'delete_group',
+      data: { layerUuid, temporary: wasTemporary, parentGroupUuid, components, groups }
+    });
   }
   
   deleteSelectedComponent() {

--- a/src/controller/layoutController.js
+++ b/src/controller/layoutController.js
@@ -10,6 +10,7 @@ import { getOptionIndexByValue, isValidLayoutName, isMac } from '../utils/utils.
 import { showSnackbar } from '../utils/snackbar.js';
 import { SubscriptionDialogController } from './subscriptionDialogController.js';
 import { PublicLayoutLoader } from '../public-cloud/publicLayoutLoader.js';
+import { UndoManager } from './undoManager.js';
 import '../FileSaver.min.js';
 
 
@@ -131,6 +132,17 @@ export class LayoutController {
    * Flag to track if Alt key was pressed when drag started (for duplication)
    */
   static dragWithAlt = false;
+
+  /**
+   * @type {?String}
+   * When set to 'add' or 'duplicate', onDragEnd records this type instead of 'move'.
+   */
+  static dragIsNewComponent = null;
+
+  /**
+   * @type {?Object}
+   */
+  static preDragPose = null;
 
   /**
    * @type {?Component | ComponentGroup}
@@ -272,6 +284,10 @@ export class LayoutController {
      * @type {Boolean}
      */
     this.readOnly = false;
+    /**
+     * @type {UndoManager}
+     */
+    this.undoManager = new UndoManager(this);
     /**
      * @type {HTMLDivElement}
      */
@@ -953,6 +969,7 @@ export class LayoutController {
           // TODO: See if there is a way to reduce the code duplication with onDragStart
           LayoutController.dragTarget = newComponent;
           LayoutController.dragDistance = 0;
+          LayoutController.dragIsNewComponent = 'add';
           newComponent.alpha = 0.5;
           newComponent.isDragging = false;
           newComponent.dragStartConnection = null;
@@ -1064,6 +1081,10 @@ export class LayoutController {
         });
       }
     }
+    this.undoManager.record({
+      type: 'add',
+      data: { componentUuid: newComp.uuid, layerUuid: this.currentLayer.uuid }
+    });
     LayoutController.selectComponent(newComp);
   }
 
@@ -1334,7 +1355,14 @@ export class LayoutController {
   onSaveStructureColor() {
     const comp = LayoutController.selectedComponent;
     if (!comp || comp.locked) return;
+    const layer = comp.layer || comp.parent;
+    const previousState = comp.serialize();
+    const childIndex = layer ? layer.children.indexOf(comp) : -1;
     comp.baseplateColor = this.#selectedStructureColor;
+    this.undoManager.record({
+      type: 'edit',
+      data: { componentUuid: comp.uuid, layerUuid: layer?.uuid, previousState, childIndex }
+    });
     this._positionSelectionToolbar();
     ui("#structureColorDialog");
   }
@@ -1606,6 +1634,10 @@ export class LayoutController {
     if (LayoutController.selectedComponent.locked) {
       return;
     }
+    const comp = LayoutController.selectedComponent;
+    const layer = comp.layer || comp.parent;
+    const previousState = comp.serialize();
+    const childIndex = layer ? layer.children.indexOf(comp) : -1;
     const componentWidthNode = document.getElementById('componentWidth');
     const componentHeightNode = document.getElementById('componentHeight');
     const componentTextNode = document.getElementById('componentText');
@@ -1682,6 +1714,10 @@ export class LayoutController {
       }
     }
     LayoutController.selectedComponent.color = window.getComputedStyle(document.getElementById('componentColorSelect').children[0]).getPropertyValue('color');
+    this.undoManager.record({
+      type: 'edit',
+      data: { componentUuid: comp.uuid, layerUuid: layer?.uuid, previousState, childIndex }
+    });
     this._positionSelectionToolbar();
     ui("#newCustomComponentDialog");
   }
@@ -1691,6 +1727,7 @@ export class LayoutController {
    * @param {Boolean} preserveReadOnly If true, preserves the current readOnly state. If false or undefined, sets readOnly to false.
    */
   reset(preserveReadOnly = false) {
+    this.undoManager.suppress();
     Connection.connectionDB.clear();
     this.hideFileMenu();
     this.layers.forEach(layer => layer.destroy());
@@ -1731,6 +1768,8 @@ export class LayoutController {
       this.readOnly = false;
     }
     this.newLayer();
+    this.undoManager.unsuppress();
+    this.undoManager.clear();
   }
 
   get currentLayer() {
@@ -1755,6 +1794,28 @@ export class LayoutController {
    */
   get layoutMetadata() {
     return { ...this.#layoutMetadata };
+  }
+
+  /**
+   * Find a component or group across all layers by UUID.
+   * @param {String} uuid
+   * @returns {?Component|ComponentGroup}
+   */
+  findComponentByUuid(uuid) {
+    for (const layer of this.layers) {
+      const comp = layer.findComponentByUuid(uuid);
+      if (comp) return comp;
+    }
+    return null;
+  }
+
+  /**
+   * Find a layer by UUID.
+   * @param {String} uuid
+   * @returns {?LayoutLayer}
+   */
+  findLayerByUuid(uuid) {
+    return this.layers.find(layer => layer.uuid === uuid) ?? null;
   }
 
   /**
@@ -2026,6 +2087,10 @@ export class LayoutController {
     }
     if (event.key === 'v' && (event.ctrlKey || event.metaKey)) {
       this.pasteComponent();
+      event.preventDefault();
+    }
+    if (LayoutController.dragTarget == null && event.key === 'z' && (event.ctrlKey || event.metaKey) && !event.shiftKey) {
+      this.undoManager.undo();
       event.preventDefault();
     }
     if (event.key === '0' && (event.ctrlKey || event.metaKey)) {
@@ -2473,6 +2538,7 @@ export class LayoutController {
       await Assets.load(unloaded);
     }
 
+    this.undoManager.suppress();
     this.reset(true);
 
     // Handle metadata from layout data and cloud info
@@ -2518,10 +2584,12 @@ export class LayoutController {
       this.drawGrid();
     }
     this.updateLayerList();
+    this.undoManager.unsuppress();
+    this.undoManager.clear();
   }
 
   /**
-   * 
+   *
    * @param {SerializedLayout} data
    * @returns {Boolean} True if the data is valid, false otherwise
    */
@@ -2592,6 +2660,8 @@ export class LayoutController {
           const clonedComponent = originalComponent.clone(layer);
           layer.addChild(clonedComponent);
 
+          LayoutController.dragIsNewComponent = 'duplicate';
+
           LayoutController.finalizeDraggedComponent(originalComponent);
 
           if (LayoutController.selectedComponent?.uuid === originalComponent.uuid || LayoutController.selectedComponent === originalComponent) {
@@ -2624,6 +2694,9 @@ export class LayoutController {
           LayoutController.dragWithAlt = false;
         }
 
+        if (!LayoutController.dragWithAlt) {
+          LayoutController.preDragPose = LayoutController.dragTarget.getPose().serialize();
+        }
         LayoutController.dragTarget.isDragging = true;
         LayoutController.getInstance()._hideSelectionToolbar();
         LayoutController.dragTarget.closeConnections();
@@ -2691,9 +2764,35 @@ export class LayoutController {
       window.app.stage.off('pointermove', LayoutController.onDragMove);
       let target = LayoutController.dragTarget;
       LayoutController.finalizeDraggedComponent(target);
+      if (LayoutController.dragIsNewComponent) {
+        const layer = target.layer || target.parent;
+        LayoutController.getInstance().undoManager.record({
+          type: LayoutController.dragIsNewComponent,
+          data: { componentUuid: target.uuid, layerUuid: layer?.uuid }
+        });
+        LayoutController.dragIsNewComponent = null;
+        LayoutController.preDragPose = null;
+      } else if (LayoutController.preDragPose) {
+        const currentPose = target.getPose().serialize();
+        if (currentPose.x !== LayoutController.preDragPose.x ||
+            currentPose.y !== LayoutController.preDragPose.y ||
+            currentPose.angle !== LayoutController.preDragPose.angle) {
+          const layer = target.layer || target.parent;
+          LayoutController.getInstance().undoManager.record({
+            type: 'move',
+            data: {
+              componentUuid: target.uuid,
+              layerUuid: layer?.uuid,
+              previousPose: LayoutController.preDragPose
+            }
+          });
+        }
+        LayoutController.preDragPose = null;
+      }
       LayoutController.dragTarget = null;
       LayoutController.dragDistance = 0;
       LayoutController.dragWithAlt = false;
+      LayoutController.dragIsNewComponent = null;
     } else {
       window.app.stage.off('pointermove', LayoutController.onPan);
       window.app.stage.off('pointermove', LayoutController.onSelectionMove);
@@ -2831,11 +2930,17 @@ export class LayoutController {
       if (LayoutController.selectedComponent.locked) {
         return;
       }
-      if (LayoutController.selectedComponent instanceof Component) {
-        this.currentLayer.setChildIndex(LayoutController.selectedComponent, this.currentLayer.children.length - 2);
-      } else if (LayoutController.selectedComponent instanceof ComponentGroup) {
-        LayoutController.selectedComponent.bringToFront();
+      const comp = LayoutController.selectedComponent;
+      const previousIndex = this.currentLayer.children.indexOf(comp);
+      if (comp instanceof Component) {
+        this.currentLayer.setChildIndex(comp, this.currentLayer.children.length - 2);
+      } else if (comp instanceof ComponentGroup) {
+        comp.bringToFront();
       }
+      this.undoManager.record({
+        type: 'zorder',
+        data: { componentUuid: comp.uuid, layerUuid: this.currentLayer.uuid, previousIndex }
+      });
     }
   }
 
@@ -2845,11 +2950,17 @@ export class LayoutController {
       if (LayoutController.selectedComponent.locked) {
         return;
       }
-      if (LayoutController.selectedComponent instanceof Component) {
-        this.currentLayer.setChildIndex(LayoutController.selectedComponent, 0);
-      } else if (LayoutController.selectedComponent instanceof ComponentGroup) {
-        LayoutController.selectedComponent.sendToBack();
+      const comp = LayoutController.selectedComponent;
+      const previousIndex = this.currentLayer.children.indexOf(comp);
+      if (comp instanceof Component) {
+        this.currentLayer.setChildIndex(comp, 0);
+      } else if (comp instanceof ComponentGroup) {
+        comp.sendToBack();
       }
+      this.undoManager.record({
+        type: 'zorder',
+        data: { componentUuid: comp.uuid, layerUuid: this.currentLayer.uuid, previousIndex }
+      });
     }
   }
 
@@ -2882,6 +2993,11 @@ export class LayoutController {
     if (component?.locked) {
       return;
     }
+    const layer = component.layer || component.parent;
+    const layerUuid = layer?.uuid;
+    const childIndex = layer ? layer.children.indexOf(component) : -1;
+    const serialized = component.serialize();
+    const baseDataAlias = component.baseData.alias;
     if (LayoutController.selectedComponent === component) {
       LayoutController.selectedComponent = null;
       this._hideSelectionToolbar();
@@ -2893,6 +3009,10 @@ export class LayoutController {
       component.isTemporary = false;
     }
     component.destroy();
+    this.undoManager.record({
+      type: 'delete',
+      data: { serialized, baseDataAlias, childIndex, layerUuid }
+    });
     component = null;
   }
   
@@ -2937,6 +3057,10 @@ export class LayoutController {
         this.currentLayer.findMatchingConnection(openCon, true);
       });
     }
+    this.undoManager.record({
+      type: 'duplicate',
+      data: { componentUuid: clone.uuid, layerUuid: this.currentLayer.uuid }
+    });
     LayoutController.selectComponent(clone);
   }
 
@@ -2980,7 +3104,17 @@ export class LayoutController {
     if (LayoutController.selectedComponent.locked) {
       return;
     }
-    LayoutController.selectedComponent.rotate();
+    const comp = LayoutController.selectedComponent;
+    const layer = comp.layer || comp.parent;
+    const usedConnections = comp.getUsedConnections();
+    const previousPose = comp.getPose().serialize();
+    const previousState = usedConnections.length === 1 ? comp.serialize() : null;
+    const childIndex = usedConnections.length === 1 ? layer.children.indexOf(comp) : -1;
+    comp.rotate();
+    this.undoManager.record({
+      type: 'rotate',
+      data: { componentUuid: comp.uuid, layerUuid: layer?.uuid, previousPose, previousState, childIndex }
+    });
     this._positionSelectionToolbar();
   }
 
@@ -2992,7 +3126,13 @@ export class LayoutController {
     if (!LayoutController.selectedComponent) {
       return;
     }
-    LayoutController.selectedComponent.locked = true;
+    const comp = LayoutController.selectedComponent;
+    const layer = comp.layer || comp.parent;
+    this.undoManager.record({
+      type: 'lock',
+      data: { componentUuid: comp.uuid, layerUuid: layer?.uuid, wasLocked: false }
+    });
+    comp.locked = true;
     this._showSelectionToolbar();
     this._positionSelectionToolbar();
   }
@@ -3005,7 +3145,13 @@ export class LayoutController {
     if (!LayoutController.selectedComponent) {
       return;
     }
-    LayoutController.selectedComponent.locked = false;
+    const comp = LayoutController.selectedComponent;
+    const layer = comp.layer || comp.parent;
+    this.undoManager.record({
+      type: 'lock',
+      data: { componentUuid: comp.uuid, layerUuid: layer?.uuid, wasLocked: true }
+    });
+    comp.locked = false;
     this._showSelectionToolbar();
     this._positionSelectionToolbar();
   }
@@ -3022,7 +3168,11 @@ export class LayoutController {
     if (selected.hasLockedComponents()) {
       return;
     }
-    
+    const layer = selected.layer || selected.parent;
+    this.undoManager.record({
+      type: 'group',
+      data: { groupUuid: selected.uuid, layerUuid: layer?.uuid }
+    });
     selected.isTemporary = false;
     this._showSelectionToolbar();
   }
@@ -3036,6 +3186,11 @@ export class LayoutController {
     if (!selected || selected.isTemporary) {
       return;
     }
+    const layer = selected.layer || selected.parent;
+    this.undoManager.record({
+      type: 'ungroup',
+      data: { groupUuid: selected.uuid, layerUuid: layer?.uuid }
+    });
     selected.isTemporary = true;
     this._showSelectionToolbar();
   }
@@ -3308,7 +3463,7 @@ export class LayoutController {
     this.currentLayer = new LayoutLayer();
     this.layers.push(this.#currentLayer);
     this.workspace.addChild(this.#currentLayer);
-    
+
     let layerNumber = this.layers.length;
     let layerName = `Layer ${layerNumber}`;
     while (this.layers.some(layer => layer.label === layerName)) {
@@ -3316,11 +3471,15 @@ export class LayoutController {
       layerName = `Layer ${layerNumber}`;
     }
     this.#currentLayer.label = layerName;
-    
+
     if (this.readOnly === true) {
       this.#currentLayer.eventMode = 'none';
       this.#currentLayer.interactiveChildren = false;
     }
+    this.undoManager.record({
+      type: 'layer_add',
+      data: { layerUuid: this.#currentLayer.uuid }
+    });
     LayoutController.selectComponent(null);
     this.updateLayerList();
   }
@@ -3344,6 +3503,7 @@ export class LayoutController {
       if (e.target.className.indexOf('instant') > -1) e.preventDefault();
     }, false);
     layerList.addEventListener('slip:reorder', (e) => {
+      const previousOrder = this.layers.map(l => l.uuid);
       const oppIndex = this.layers.length - 1 - e.detail.originalIndex;
       const oppSpliceIndex = this.layers.length - 1 - e.detail.spliceIndex;
       const layer = this.layers[oppIndex];
@@ -3351,9 +3511,14 @@ export class LayoutController {
       this.layers.splice(oppSpliceIndex, 0, layer);
       e.target.parentNode.insertBefore(e.target, e.detail.insertBefore);
       this.workspace.setChildIndex(layer, oppSpliceIndex);
+      this.undoManager.record({
+        type: 'layer_reorder',
+        data: { previousOrder }
+      });
       this.updateLayerList();
     }, false);
     mobileLayerList.addEventListener('slip:reorder', (e) => {
+      const previousOrder = this.layers.map(l => l.uuid);
       const oppIndex = this.layers.length - 1 - e.detail.originalIndex;
       const oppSpliceIndex = this.layers.length - 1 - e.detail.spliceIndex;
       const layer = this.layers[oppIndex];
@@ -3361,6 +3526,10 @@ export class LayoutController {
       this.layers.splice(oppSpliceIndex, 0, layer);
       e.target.parentNode.insertBefore(e.target, e.detail.insertBefore);
       this.workspace.setChildIndex(layer, oppSpliceIndex);
+      this.undoManager.record({
+        type: 'layer_reorder',
+        data: { previousOrder }
+      });
       this.updateLayerList();
     }, false);
     new Slip(layerList);
@@ -3405,6 +3574,22 @@ export class LayoutController {
     console.log(`Delete Layer ${index}`);
     if (this.layers.length > 1) {
       let tempLayer = this.layers[index];
+      const serializedComponents = [];
+      for (const child of tempLayer.children) {
+        if (child instanceof Component) {
+          serializedComponents.push(child.serialize());
+        }
+      }
+      this.undoManager.record({
+        type: 'layer_delete',
+        data: {
+          layerUuid: tempLayer.uuid,
+          layerName: tempLayer.label,
+          layerOpacity: tempLayer.alpha,
+          layerIndex: index,
+          serializedComponents
+        }
+      });
       this.layers.splice(index, 1);
       if (this.#currentLayer === tempLayer) {
         this.currentLayer = this.layers[0];
@@ -3451,8 +3636,17 @@ export class LayoutController {
     }
     // Ensure opacity is within valid range
     layerOpacity = Math.max(0, Math.min(100, layerOpacity));
-    this.layers[index].label = layerName;
-    this.layers[index].alpha = layerOpacity / 100;
+    const layer = this.layers[index];
+    this.undoManager.record({
+      type: 'layer_edit',
+      data: {
+        layerUuid: layer.uuid,
+        previousName: layer.label,
+        previousOpacity: layer.alpha
+      }
+    });
+    layer.label = layerName;
+    layer.alpha = layerOpacity / 100;
     this.updateLayerList();
     ui("#editLayerDialog");
   }

--- a/src/controller/undoManager.js
+++ b/src/controller/undoManager.js
@@ -1,4 +1,5 @@
 import { Component } from '../model/component.js';
+import { ComponentGroup } from '../model/componentGroup.js';
 import { LayoutController } from './layoutController.js';
 import { LayoutLayer } from '../model/layoutLayer.js';
 
@@ -304,32 +305,50 @@ export class UndoManager {
   }
 
   /**
-   * @param {{groupUuid: String, layerUuid: String}} data
+   * @param {{groupUuid: String, memberComponentUuid: String, layerUuid: String}} data
    */
   #undoGroup(data) {
     const layer = this.#controller.findLayerByUuid(data.layerUuid);
     if (!layer) return;
-    const comp = layer.findComponentByUuid(data.groupUuid);
-    if (comp && 'isTemporary' in comp) {
-      comp.isTemporary = true;
-      if (LayoutController.selectedComponent === comp) {
-        this.#controller._showSelectionToolbar();
-      }
+    const group = this.#findGroupByUuid(layer, data.memberComponentUuid, data.groupUuid);
+    if (!group) return;
+    group.isTemporary = true;
+    if (LayoutController.selectedComponent === group) {
+      this.#controller._showSelectionToolbar();
+    } else {
+      LayoutController.selectComponent(group);
     }
   }
 
   /**
-   * @param {{groupUuid: String, layerUuid: String}} data
+   * @param {{groupUuid: String, componentUuids: Array<String>, layerUuid: String}} data
    */
   #undoUngroup(data) {
     const layer = this.#controller.findLayerByUuid(data.layerUuid);
     if (!layer) return;
-    const comp = layer.findComponentByUuid(data.groupUuid);
-    if (comp && 'isTemporary' in comp) {
-      comp.isTemporary = false;
-      if (LayoutController.selectedComponent === comp) {
+    const existing = this.#findGroupByUuid(layer, data.componentUuids[0], data.groupUuid);
+    if (existing) {
+      existing.isTemporary = false;
+      if (LayoutController.selectedComponent === existing) {
         this.#controller._showSelectionToolbar();
       }
+      return;
+    }
+    LayoutController.selectComponent(null);
+    const newGroup = new ComponentGroup(false);
+    for (const uuid of data.componentUuids) {
+      const comp = layer.findComponentByUuid(uuid);
+      if (!comp) continue;
+      if (comp.group) {
+        if (!comp.group.group) {
+          newGroup.addComponent(comp.group);
+        }
+      } else {
+        newGroup.addComponent(comp);
+      }
+    }
+    if (newGroup.components.length > 0) {
+      LayoutController.selectComponent(newGroup);
     }
   }
 
@@ -414,6 +433,24 @@ export class UndoManager {
       this.#controller.workspace.setChildIndex(layer, i);
     });
     this.#controller.updateLayerList();
+  }
+
+  /**
+   * Locate a ComponentGroup by traversing upward from a known component.
+   * @param {LayoutLayer} layer
+   * @param {String} componentUuid - UUID of a leaf Component inside the group
+   * @param {String} groupUuid - UUID of the target group
+   * @returns {?ComponentGroup}
+   */
+  #findGroupByUuid(layer, componentUuid, groupUuid) {
+    const comp = layer.findComponentByUuid(componentUuid);
+    if (!comp) return null;
+    let current = comp.group;
+    while (current) {
+      if (current.uuid === groupUuid) return current;
+      current = current.group;
+    }
+    return null;
   }
 
   /**

--- a/src/controller/undoManager.js
+++ b/src/controller/undoManager.js
@@ -319,11 +319,15 @@ export class UndoManager {
       }
     } else {
       comp.deleteCollisionTree();
+      comp.closeConnections();
       comp.position.set(data.previousPose.x, data.previousPose.y);
       comp.sprite.rotation = data.previousPose.angle;
       comp.insertCollisionTree();
       comp.connections.forEach((connection) => {
         connection.updateCircle();
+        if (!connection.otherConnection) {
+          layer.findMatchingConnection(connection, true);
+        }
       });
       if (LayoutController.selectedComponent === comp) {
         this.#controller._positionSelectionToolbar();
@@ -348,6 +352,9 @@ export class UndoManager {
       comp.insertCollisionTree();
       comp.connections.forEach((connection) => {
         connection.updateCircle();
+        if (!connection.otherConnection) {
+          layer.findMatchingConnection(connection, true);
+        }
       });
       allOpenConnections.push(...comp.getOpenConnections());
     }

--- a/src/controller/undoManager.js
+++ b/src/controller/undoManager.js
@@ -118,6 +118,12 @@ export class UndoManager {
       case 'lock':
         this.#undoLock(entry.data);
         break;
+      case 'lock_perm_group':
+        this.#undoLockPermGroup(entry.data);
+        break;
+      case 'lock_temp_group':
+        this.#undoLockTempGroup(entry.data);
+        break;
       case 'zorder':
         this.#undoZOrder(entry.data);
         break;
@@ -289,6 +295,38 @@ export class UndoManager {
     if (LayoutController.selectedComponent === comp) {
       this.#controller._showSelectionToolbar();
       this.#controller._positionSelectionToolbar();
+    }
+  }
+
+  /**
+   * @param {{groupUuid: String, memberComponentUuid: String, layerUuid: String, wasLocked: Boolean}} data
+   */
+  #undoLockPermGroup(data) {
+    const layer = this.#controller.findLayerByUuid(data.layerUuid);
+    if (!layer) return;
+    const group = this.#findGroupByUuid(layer, data.memberComponentUuid, data.groupUuid);
+    if (!group) return;
+    group.locked = data.wasLocked;
+    if (LayoutController.selectedComponent === group) {
+      this.#controller._showSelectionToolbar();
+      this.#controller._positionSelectionToolbar();
+    }
+  }
+
+  /**
+   * @param {{layerUuid: String, members: Array<{type: String, componentUuid: ?String, memberComponentUuid: ?String, groupUuid: ?String, wasLocked: Boolean}>}} data
+   */
+  #undoLockTempGroup(data) {
+    const layer = this.#controller.findLayerByUuid(data.layerUuid);
+    if (!layer) return;
+    for (const member of data.members) {
+      if (member.type === 'group') {
+        const group = this.#findGroupByUuid(layer, member.memberComponentUuid, member.groupUuid);
+        if (group) group.locked = member.wasLocked;
+      } else {
+        const comp = layer.findComponentByUuid(member.componentUuid);
+        if (comp) comp.locked = member.wasLocked;
+      }
     }
   }
 

--- a/src/controller/undoManager.js
+++ b/src/controller/undoManager.js
@@ -109,8 +109,14 @@ export class UndoManager {
       case 'move':
         this.#undoMove(entry.data);
         break;
+      case 'move_group':
+        this.#undoMoveGroup(entry.data);
+        break;
       case 'rotate':
         this.#undoRotate(entry.data);
+        break;
+      case 'rotate_group':
+        this.#undoRotateGroup(entry.data);
         break;
       case 'edit':
         this.#undoEdit(entry.data);
@@ -209,6 +215,30 @@ export class UndoManager {
   }
 
   /**
+   * @param {{layerUuid: String, components: Array<{componentUuid: String, previousPose: {x: Number, y: Number, angle: Number}}>}} data
+   */
+  #undoMoveGroup(data) {
+    const layer = this.#controller.findLayerByUuid(data.layerUuid);
+    if (!layer) return;
+    const allOpenConnections = [];
+    for (const entry of data.components) {
+      const comp = layer.findComponentByUuid(entry.componentUuid);
+      if (!comp) continue;
+      comp.deleteCollisionTree();
+      comp.closeConnections();
+      comp.position.set(entry.previousPose.x, entry.previousPose.y);
+      comp.sprite.rotation = entry.previousPose.angle;
+      comp.insertCollisionTree();
+      allOpenConnections.push(...comp.getOpenConnections());
+    }
+    for (const openCon of allOpenConnections) {
+      layer.findMatchingConnection(openCon, true);
+    }
+    allOpenConnections.length = 0;
+    this.#controller._positionSelectionToolbar();
+  }
+
+  /**
    * @param {{componentUuid: String, layerUuid: String, previousPose: {x: Number, y: Number, angle: Number}, previousState: ?Object, childIndex: Number}} data
    */
   #undoRotate(data) {
@@ -250,6 +280,32 @@ export class UndoManager {
         this.#controller._positionSelectionToolbar();
       }
     }
+  }
+
+  /**
+   * @param {{layerUuid: String, components: Array<{componentUuid: String, previousPose: {x: Number, y: Number, angle: Number}}>}} data
+   */
+  #undoRotateGroup(data) {
+    const layer = this.#controller.findLayerByUuid(data.layerUuid);
+    if (!layer) return;
+    const allOpenConnections = [];
+    for (const entry of data.components) {
+      const comp = layer.findComponentByUuid(entry.componentUuid);
+      if (!comp) continue;
+      comp.deleteCollisionTree();
+      comp.closeConnections();
+      comp.position.set(entry.previousPose.x, entry.previousPose.y);
+      comp.sprite.rotation = entry.previousPose.angle;
+      comp.insertCollisionTree();
+      comp.connections.forEach((connection) => {
+        connection.updateCircle();
+      });
+      allOpenConnections.push(...comp.getOpenConnections());
+    }
+    for (const openCon of allOpenConnections) {
+      layer.findMatchingConnection(openCon, true);
+    }
+    this.#controller._positionSelectionToolbar();
   }
 
   /**
@@ -501,6 +557,13 @@ export class UndoManager {
     for (const entry of this.#stack) {
       if (entry.data.componentUuid === oldUuid) {
         entry.data.componentUuid = newUuid;
+      }
+      if (entry.data.components) {
+        for (const compEntry of entry.data.components) {
+          if (compEntry.componentUuid === oldUuid) {
+            compEntry.componentUuid = newUuid;
+          }
+        }
       }
     }
   }

--- a/src/controller/undoManager.js
+++ b/src/controller/undoManager.js
@@ -104,6 +104,9 @@ export class UndoManager {
       case 'duplicate':
         this.#undoAdd(entry.data);
         break;
+      case 'duplicate_group':
+        this.#undoDuplicateGroup(entry.data);
+        break;
       case 'delete':
         this.#undoDelete(entry.data);
         break;
@@ -171,6 +174,53 @@ export class UndoManager {
       LayoutController.selectComponent(nextComp);
     }
     this.#controller.deleteComponent(comp);
+  }
+
+  /**
+   * @param {{componentUuids: Array<String>, layerUuid: String}} data
+   */
+  #undoDuplicateGroup(data) {
+    const layer = this.#controller.findLayerByUuid(data.layerUuid);
+    if (!layer) return;
+    const destroyedGroups = new Set();
+    const componentsToDelete = [];
+    for (const uuid of data.componentUuids) {
+      const comp = layer.findComponentByUuid(uuid);
+      if (!comp || comp.destroyed) continue;
+      let topGroup = null;
+      let current = comp.group;
+      while (current) {
+        topGroup = current;
+        current = current.group;
+      }
+      if (topGroup && !destroyedGroups.has(topGroup.uuid)) {
+        destroyedGroups.add(topGroup.uuid);
+        if (!topGroup.isTemporary) {
+          if (LayoutController.selectedComponent === topGroup) {
+            LayoutController.selectComponent(null);
+          }
+          topGroup.destroy();
+        } else {
+          const groupComps = topGroup.getAllComponents();
+          if (LayoutController.selectedComponent === topGroup) {
+            LayoutController.selectComponent(null);
+          }
+          if (!topGroup.destroyed) {
+            topGroup.destroy();
+          }
+          componentsToDelete.push(...groupComps);
+        }
+      } else if (!topGroup) {
+        componentsToDelete.push(comp);
+      }
+    }
+    for (const comp of componentsToDelete) {
+      if (comp.destroyed) continue;
+      if (LayoutController.selectedComponent === comp) {
+        LayoutController.selectComponent(null);
+      }
+      this.#controller.deleteComponent(comp);
+    }
   }
 
   /**

--- a/src/controller/undoManager.js
+++ b/src/controller/undoManager.js
@@ -1,5 +1,6 @@
 import { Component } from '../model/component.js';
 import { ComponentGroup } from '../model/componentGroup.js';
+import { Connection } from '../model/connection.js';
 import { LayoutController } from './layoutController.js';
 import { LayoutLayer } from '../model/layoutLayer.js';
 
@@ -106,6 +107,9 @@ export class UndoManager {
       case 'delete':
         this.#undoDelete(entry.data);
         break;
+      case 'delete_group':
+        this.#undoDeleteGroup(entry.data);
+        break;
       case 'move':
         this.#undoMove(entry.data);
         break;
@@ -190,6 +194,51 @@ export class UndoManager {
     openConnections.forEach((openCon) => {
       layer.findMatchingConnection(openCon, true);
     });
+  }
+
+  #undoDeleteGroup(data) {
+    const layer = this.#controller.findLayerByUuid(data.layerUuid);
+    if (!layer) return;
+    layer._reconstructGroups(data.groups);
+    for (const entry of data.components) {
+      for (const conn of entry.serialized.connections || []) {
+        Connection.connectionDB.delete(conn.uuid);
+      }
+    }
+    const restored = [];
+    for (const entry of data.components) {
+      const baseData = this.#controller.trackData.bundles[0].assets.find(
+        a => a.alias === entry.baseDataAlias
+      );
+      if (!baseData) continue;
+      const comp = Component.deserialize(baseData, entry.serialized, layer);
+      if (!comp) continue;
+      layer.addChild(comp);
+      restored.push({ comp, childIndex: entry.childIndex });
+    }
+    restored.sort((a, b) => a.childIndex - b.childIndex);
+    for (const { comp, childIndex } of restored) {
+      const index = Math.min(childIndex, layer.children.length - 1);
+      if (index >= 0 && index < layer.children.length - 1) {
+        layer.setChildIndex(comp, index);
+      }
+    }
+    for (const { comp } of restored) {
+      const openConnections = comp.getOpenConnections();
+      openConnections.forEach((openCon) => {
+        layer.findMatchingConnection(openCon, true);
+      });
+    }
+    const groupMap = layer.getGroupLookupMap();
+    if (!groupMap) return;
+    const topGroupUuid = data.groups[0]?.uuid;
+    const topGroup = groupMap.get(topGroupUuid);
+    layer.cleanupGroupDeserialization();
+    if (!topGroup) return;
+    if (data.temporary) {
+      topGroup.isTemporary = true;
+    }
+    LayoutController.selectComponent(topGroup);
   }
 
   /**
@@ -471,6 +520,7 @@ export class UndoManager {
    * @param {{layerUuid: String, layerIndex: Number, serializedLayer: Object}} data
    */
   #undoLayerDelete(data) {
+    Connection.connectionDB.clear();
     const layer = new LayoutLayer();
     layer.uuid = data.layerUuid;
     layer.deserialize(data.serializedLayer);

--- a/src/controller/undoManager.js
+++ b/src/controller/undoManager.js
@@ -1,0 +1,434 @@
+import { Component } from '../model/component.js';
+import { LayoutController } from './layoutController.js';
+import { LayoutLayer } from '../model/layoutLayer.js';
+
+/**
+ * Maximum number of undo entries to retain. Older entries are discarded.
+ * @type {Number}
+ */
+export let UNDO_BUFFER_SIZE = 3;
+
+/**
+ * @typedef {Object} UndoEntry
+ * @property {String} type
+ * @property {Object} data
+ */
+
+/**
+ * Manages undo operations for layout editing.
+ * The controller records undo entries describing inverse operations for each user action, and executes them when requested.
+ */
+export class UndoManager {
+  /** @type {Array<UndoEntry>} */
+  #stack = [];
+
+  /** @type {LayoutController} */
+  #controller;
+
+  #isUndoing = false;
+  #suppressDepth = 0;
+
+  /**
+   * @param {LayoutController} controller
+   */
+  constructor(controller) {
+    this.#controller = controller;
+  }
+
+  /**
+   * Record an undo entry. No-op when readOnly, during undo execution, or while suppressed.
+   * @param {UndoEntry} entry
+   */
+  record(entry) {
+    if (this.#controller.readOnly || this.#isUndoing || this.#suppressDepth > 0) return;
+    this.#stack.push(entry);
+    if (this.#stack.length > UNDO_BUFFER_SIZE) {
+      this.#stack.shift();
+    }
+  }
+
+  /**
+   * Pop the most recent entry and execute its inverse operation.
+   */
+  undo() {
+    if (this.#stack.length === 0) return;
+    const entry = this.#stack.pop();
+    this.#isUndoing = true;
+    try {
+      this.#execute(entry);
+    } finally {
+      this.#isUndoing = false;
+    }
+  }
+
+  /**
+   * Remove all entries from the undo stack.
+   */
+  clear() {
+    this.#stack = [];
+  }
+
+  /**
+   * Increment the suppression depth. While depth > 0, record() is a no-op.
+   * Calls must be balanced with {@link unsuppress}.
+   */
+  suppress() {
+    this.#suppressDepth++;
+  }
+
+  /**
+   * Decrement the suppression depth. Recording resumes when depth reaches 0.
+   */
+  unsuppress() {
+    if (this.#suppressDepth > 0) {
+      this.#suppressDepth--;
+    }
+  }
+
+  /**
+   * @returns {Number} The number of entries in the undo stack.
+   */
+  get length() {
+    return this.#stack.length;
+  }
+
+  /**
+   * Dispatch an undo entry to the appropriate handler.
+   * @param {UndoEntry} entry
+   */
+  #execute(entry) {
+    switch (entry.type) {
+      case 'add':
+      case 'duplicate':
+        this.#undoAdd(entry.data);
+        break;
+      case 'delete':
+        this.#undoDelete(entry.data);
+        break;
+      case 'move':
+        this.#undoMove(entry.data);
+        break;
+      case 'rotate':
+        this.#undoRotate(entry.data);
+        break;
+      case 'edit':
+        this.#undoEdit(entry.data);
+        break;
+      case 'lock':
+        this.#undoLock(entry.data);
+        break;
+      case 'zorder':
+        this.#undoZOrder(entry.data);
+        break;
+      case 'group':
+        this.#undoGroup(entry.data);
+        break;
+      case 'ungroup':
+        this.#undoUngroup(entry.data);
+        break;
+      case 'layer_add':
+        this.#undoLayerAdd(entry.data);
+        break;
+      case 'layer_delete':
+        this.#undoLayerDelete(entry.data);
+        break;
+      case 'layer_edit':
+        this.#undoLayerEdit(entry.data);
+        break;
+      case 'layer_reorder':
+        this.#undoLayerReorder(entry.data);
+        break;
+    }
+  }
+
+  /**
+   * @param {{componentUuid: String, layerUuid: String}} data
+   */
+  #undoAdd(data) {
+    const layer = this.#controller.findLayerByUuid(data.layerUuid);
+    if (!layer) return;
+    const comp = layer.findComponentByUuid(data.componentUuid);
+    if (!comp) return;
+    if (LayoutController.selectedComponent === comp) {
+      let nextComp = LayoutController.selectedComponent.getAdjacentComponent();
+      LayoutController.selectComponent(nextComp);
+    }
+    this.#controller.deleteComponent(comp);
+  }
+
+  /**
+   * @param {{baseDataAlias: String, serialized: Object, childIndex: Number, layerUuid: String}} data
+   */
+  #undoDelete(data) {
+    const layer = this.#controller.findLayerByUuid(data.layerUuid);
+    if (!layer) return;
+    const baseData = this.#controller.trackData.bundles[0].assets.find(
+      a => a.alias === data.baseDataAlias
+    );
+    if (!baseData) return;
+    const comp = Component.deserialize(baseData, data.serialized, layer);
+    if (!comp) return;
+    const index = Math.min(data.childIndex, layer.children.length - 1);
+    layer.addChild(comp);
+    if (index >= 0 && index < layer.children.length - 1) {
+      layer.setChildIndex(comp, index);
+    }
+    const openConnections = comp.getOpenConnections();
+    openConnections.forEach((openCon) => {
+      layer.findMatchingConnection(openCon, true);
+    });
+  }
+
+  /**
+   * @param {{componentUuid: String, layerUuid: String, previousPose: {x: Number, y: Number, angle: Number}}} data
+   */
+  #undoMove(data) {
+    const layer = this.#controller.findLayerByUuid(data.layerUuid);
+    if (!layer) return;
+    const comp = layer.findComponentByUuid(data.componentUuid);
+    if (!comp) return;
+    comp.deleteCollisionTree();
+    comp.closeConnections();
+    comp.position.set(data.previousPose.x, data.previousPose.y);
+    comp.sprite.rotation = data.previousPose.angle;
+    comp.insertCollisionTree();
+    const openConnections = comp.getOpenConnections();
+    openConnections.forEach((openCon) => {
+      layer.findMatchingConnection(openCon, true);
+    });
+    if (LayoutController.selectedComponent === comp) {
+      this.#controller._positionSelectionToolbar();
+    }
+  }
+
+  /**
+   * @param {{componentUuid: String, layerUuid: String, previousPose: {x: Number, y: Number, angle: Number}, previousState: ?Object, childIndex: Number}} data
+   */
+  #undoRotate(data) {
+    const layer = this.#controller.findLayerByUuid(data.layerUuid);
+    if (!layer) return;
+    const comp = layer.findComponentByUuid(data.componentUuid);
+    if (!comp) return;
+    if (data.previousState) {
+      const baseData = comp.baseData;
+      const childIndex = data.childIndex;
+      const wasSelected = LayoutController.selectedComponent === comp;
+      if (wasSelected) {
+        LayoutController.selectComponent(null);
+      }
+      comp.destroy();
+      const restored = Component.deserialize(baseData, data.previousState, layer);
+      if (!restored) return;
+      layer.addChild(restored);
+      if (childIndex >= 0 && childIndex < layer.children.length - 1) {
+        layer.setChildIndex(restored, childIndex);
+      }
+      const openConnections = restored.getOpenConnections();
+      openConnections.forEach((openCon) => {
+        layer.findMatchingConnection(openCon, true);
+      });
+      this.#updateComponentUuid(data.componentUuid, restored.uuid);
+      if (wasSelected) {
+        LayoutController.selectComponent(restored);
+      }
+    } else {
+      comp.deleteCollisionTree();
+      comp.position.set(data.previousPose.x, data.previousPose.y);
+      comp.sprite.rotation = data.previousPose.angle;
+      comp.insertCollisionTree();
+      comp.connections.forEach((connection) => {
+        connection.updateCircle();
+      });
+      if (LayoutController.selectedComponent === comp) {
+        this.#controller._positionSelectionToolbar();
+      }
+    }
+  }
+
+  /**
+   * @param {{componentUuid: String, layerUuid: String, previousState: Object, childIndex: Number}} data
+   */
+  #undoEdit(data) {
+    const layer = this.#controller.findLayerByUuid(data.layerUuid);
+    if (!layer) return;
+    const comp = layer.findComponentByUuid(data.componentUuid);
+    if (!comp) return;
+    const baseData = comp.baseData;
+    const childIndex = layer.children.indexOf(comp);
+    const wasSelected = LayoutController.selectedComponent === comp;
+    if (wasSelected) {
+      LayoutController.selectComponent(null);
+    }
+    comp.destroy();
+    const restored = Component.deserialize(baseData, data.previousState, layer);
+    if (!restored) return;
+    layer.addChild(restored);
+    if (childIndex >= 0 && childIndex < layer.children.length - 1) {
+      layer.setChildIndex(restored, childIndex);
+    }
+    const openConnections = restored.getOpenConnections();
+    openConnections.forEach((openCon) => {
+      layer.findMatchingConnection(openCon, true);
+    });
+    this.#updateComponentUuid(data.componentUuid, restored.uuid);
+    if (wasSelected) {
+      LayoutController.selectComponent(restored);
+    }
+  }
+
+  /**
+   * @param {{componentUuid: String, layerUuid: String, wasLocked: Boolean}} data
+   */
+  #undoLock(data) {
+    const layer = this.#controller.findLayerByUuid(data.layerUuid);
+    if (!layer) return;
+    const comp = layer.findComponentByUuid(data.componentUuid);
+    if (!comp) return;
+    comp.locked = data.wasLocked;
+    if (LayoutController.selectedComponent === comp) {
+      this.#controller._showSelectionToolbar();
+      this.#controller._positionSelectionToolbar();
+    }
+  }
+
+  /**
+   * @param {{componentUuid: String, layerUuid: String, previousIndex: Number}} data
+   */
+  #undoZOrder(data) {
+    const layer = this.#controller.findLayerByUuid(data.layerUuid);
+    if (!layer) return;
+    const comp = layer.findComponentByUuid(data.componentUuid);
+    if (!comp) return;
+    const index = Math.min(data.previousIndex, layer.children.length - 1);
+    layer.setChildIndex(comp, Math.max(0, index));
+  }
+
+  /**
+   * @param {{groupUuid: String, layerUuid: String}} data
+   */
+  #undoGroup(data) {
+    const layer = this.#controller.findLayerByUuid(data.layerUuid);
+    if (!layer) return;
+    const comp = layer.findComponentByUuid(data.groupUuid);
+    if (comp && 'isTemporary' in comp) {
+      comp.isTemporary = true;
+      if (LayoutController.selectedComponent === comp) {
+        this.#controller._showSelectionToolbar();
+      }
+    }
+  }
+
+  /**
+   * @param {{groupUuid: String, layerUuid: String}} data
+   */
+  #undoUngroup(data) {
+    const layer = this.#controller.findLayerByUuid(data.layerUuid);
+    if (!layer) return;
+    const comp = layer.findComponentByUuid(data.groupUuid);
+    if (comp && 'isTemporary' in comp) {
+      comp.isTemporary = false;
+      if (LayoutController.selectedComponent === comp) {
+        this.#controller._showSelectionToolbar();
+      }
+    }
+  }
+
+  /**
+   * @param {{layerUuid: String}} data
+   */
+  #undoLayerAdd(data) {
+    const layer = this.#controller.findLayerByUuid(data.layerUuid);
+    if (!layer) return;
+    const index = this.#controller.layers.indexOf(layer);
+    if (index === -1) return;
+    if (this.#controller.layers.length <= 1) return;
+    this.#controller.layers.splice(index, 1);
+    if (this.#controller.currentLayer === layer) {
+      this.#controller.currentLayer = this.#controller.layers[0];
+    }
+    if (LayoutController.selectedComponent && LayoutController.selectedComponent.layer === layer) {
+      LayoutController.selectComponent(null);
+    }
+    this.#controller.workspace.removeChild(layer);
+    layer.destroy();
+    this.#controller.updateLayerList();
+  }
+
+  /**
+   * @param {{layerUuid: String, layerName: String, layerOpacity: Number, layerIndex: Number, serializedComponents: ?Array<Object>}} data
+   */
+  #undoLayerDelete(data) {
+    const layer = new LayoutLayer();
+    layer.uuid = data.layerUuid;
+    layer.label = data.layerName;
+    layer.alpha = data.layerOpacity;
+    const index = Math.min(data.layerIndex, this.#controller.layers.length);
+    this.#controller.layers.splice(index, 0, layer);
+    this.#controller.workspace.addChildAt(layer, index);
+    if (data.serializedComponents && data.serializedComponents.length > 0) {
+      for (const compData of data.serializedComponents) {
+        const baseData = this.#controller.trackData.bundles[0].assets.find(
+          a => a.alias === compData.type
+        );
+        if (!baseData) continue;
+        const comp = Component.deserialize(baseData, compData, layer);
+        if (comp) {
+          layer.addChild(comp);
+        }
+      }
+      // Restore connections
+      for (const child of layer.children) {
+        if (child instanceof Component) {
+          const openConnections = child.getOpenConnections();
+          openConnections.forEach((openCon) => {
+            layer.findMatchingConnection(openCon, true);
+          });
+        }
+      }
+    }
+    this.#controller.updateLayerList();
+  }
+
+  /**
+   * @param {{layerUuid: String, previousName: String, previousOpacity: Number}} data
+   */
+  #undoLayerEdit(data) {
+    const layer = this.#controller.findLayerByUuid(data.layerUuid);
+    if (!layer) return;
+    layer.label = data.previousName;
+    layer.alpha = data.previousOpacity;
+    this.#controller.updateLayerList();
+  }
+
+  /**
+   * @param {{previousOrder: Array<String>}} data
+   */
+  #undoLayerReorder(data) {
+    const currentOrder = this.#controller.layers.map(l => l.uuid);
+    if (data.previousOrder.length !== currentOrder.length) return;
+    const reordered = data.previousOrder.map(uuid =>
+      this.#controller.layers.find(l => l.uuid === uuid)
+    ).filter(Boolean);
+    if (reordered.length !== this.#controller.layers.length) return;
+    this.#controller.layers.splice(0, this.#controller.layers.length, ...reordered);
+    reordered.forEach((layer, i) => {
+      this.#controller.workspace.setChildIndex(layer, i);
+    });
+    this.#controller.updateLayerList();
+  }
+
+  /**
+   * Update remaining stack entries when a component is recreated with a new UUID.
+   * @param {String} oldUuid
+   * @param {String} newUuid
+   */
+  #updateComponentUuid(oldUuid, newUuid) {
+    if (oldUuid === newUuid) return;
+    for (const entry of this.#stack) {
+      if (entry.data.componentUuid === oldUuid) {
+        entry.data.componentUuid = newUuid;
+      }
+    }
+  }
+}
+

--- a/src/controller/undoManager.js
+++ b/src/controller/undoManager.js
@@ -355,18 +355,17 @@ export class UndoManager {
   }
 
   /**
-   * @param {{layerUuid: String, layerName: String, layerOpacity: Number, layerIndex: Number, serializedComponents: ?Array<Object>}} data
+   * @param {{layerUuid: String, layerIndex: Number, serializedLayer: Object}} data
    */
   #undoLayerDelete(data) {
     const layer = new LayoutLayer();
     layer.uuid = data.layerUuid;
-    layer.label = data.layerName;
-    layer.alpha = data.layerOpacity;
+    layer.deserialize(data.serializedLayer);
     const index = Math.min(data.layerIndex, this.#controller.layers.length);
     this.#controller.layers.splice(index, 0, layer);
     this.#controller.workspace.addChildAt(layer, index);
-    if (data.serializedComponents && data.serializedComponents.length > 0) {
-      for (const compData of data.serializedComponents) {
+    if (data.serializedLayer.components) {
+      for (const compData of data.serializedLayer.components) {
         const baseData = this.#controller.trackData.bundles[0].assets.find(
           a => a.alias === compData.type
         );
@@ -376,7 +375,7 @@ export class UndoManager {
           layer.addChild(comp);
         }
       }
-      // Restore connections
+      layer.cleanupGroupDeserialization();
       for (const child of layer.children) {
         if (child instanceof Component) {
           const openConnections = child.getOpenConnections();

--- a/src/controller/undoManager.js
+++ b/src/controller/undoManager.js
@@ -140,6 +140,9 @@ export class UndoManager {
       case 'zorder':
         this.#undoZOrder(entry.data);
         break;
+      case 'zorder_group':
+        this.#undoZOrderGroup(entry.data);
+        break;
       case 'group':
         this.#undoGroup(entry.data);
         break;
@@ -502,6 +505,21 @@ export class UndoManager {
     if (!comp) return;
     const index = Math.min(data.previousIndex, layer.children.length - 1);
     layer.setChildIndex(comp, Math.max(0, index));
+  }
+
+  /**
+   * @param {{layerUuid: String, components: Array<{componentUuid: String, previousIndex: Number}>}} data
+   */
+  #undoZOrderGroup(data) {
+    const layer = this.#controller.findLayerByUuid(data.layerUuid);
+    if (!layer) return;
+    const sorted = [...data.components].sort((a, b) => a.previousIndex - b.previousIndex);
+    for (const entry of sorted) {
+      const comp = layer.findComponentByUuid(entry.componentUuid);
+      if (!comp) continue;
+      const index = Math.min(entry.previousIndex, layer.children.length - 1);
+      layer.setChildIndex(comp, Math.max(0, index));
+    }
   }
 
   /**

--- a/src/controller/undoManager.js
+++ b/src/controller/undoManager.js
@@ -513,7 +513,7 @@ export class UndoManager {
   #undoZOrderGroup(data) {
     const layer = this.#controller.findLayerByUuid(data.layerUuid);
     if (!layer) return;
-    const sorted = [...data.components].sort((a, b) => a.previousIndex - b.previousIndex);
+    const sorted = [...data.components].sort((a, b) => b.previousIndex - a.previousIndex);
     for (const entry of sorted) {
       const comp = layer.findComponentByUuid(entry.componentUuid);
       if (!comp) continue;

--- a/src/model/layoutLayer.js
+++ b/src/model/layoutLayer.js
@@ -99,6 +99,20 @@ export class LayoutLayer extends Container {
     }
 
     /**
+     * Find a component or group in this layer by UUID.
+     * @param {String} uuid
+     * @returns {?Component|ComponentGroup}
+     */
+    findComponentByUuid(uuid) {
+        for (const child of this.children) {
+            if ((child instanceof Component || child instanceof ComponentGroup) && child.uuid === uuid) {
+                return child;
+            }
+        }
+        return null;
+    }
+
+    /**
      * Check if this LayoutLayer is equal to another LayoutLayer
      * @param {LayoutLayer} other 
      * @returns {Boolean} True if this LayoutLayer is equal to the other, false otherwise


### PR DESCRIPTION
## Summary

- **New undo system** (`src/controller/undoManager.js`) using the Command Pattern with a fixed-size buffer (default 3 entries). Stores minimal inverse data per operation rather than full layout snapshots, keeping memory usage low even on mobile devices.
- **Supports undoing all layout-modifying operations**: add, delete, move, rotate, edit (color/size/shape), duplicate, lock/unlock, z-order changes, group/ungroup, and all layer operations (add, delete, edit, reorder).
- **Hotkey**: Ctrl+Z / Cmd+Z triggers undo (no redo).
- **Suppression system** with nested depth tracking prevents recording during automated bulk operations (layout import, reset) that should not be undoable.
- **Connection restoration**: undo-delete and undo-edit properly restore connections with adjacent components after deserialization.
- **Rotate undo** handles 0-connection and 1+ connection components differently — 0-connection uses simple pose restore, 1-connection uses full serialize/deserialize to preserve connection geometry.
- **UUID stability fix**: when undo recreates a component via deserialize (rotate/edit), remaining stack entries are updated to reference the new UUID so consecutive undos work correctly.
- **Drag undo improvements**: Alt+Drag clone and Component Browser drag-to-add both record a single 'add'/'duplicate' entry at the final drop position instead of separate add+move entries.
- **Helper methods**: `LayoutLayer.findComponentByUuid()`, `LayoutController.findComponentByUuid()`, `LayoutController.findLayerByUuid()`.
- **Comprehensive test suite** (`spec/support/undoManager.spec.mjs`): 30 specs covering buffer management, suppression, LIFO ordering, all undo entry types, UUID update after component recreation, and a regression test for consecutive 1-connection rotations.

## Test plan

- [x] Run test suite: `CI=true npx jasmine-browser-runner runSpecs --config=spec/support/jasmine-browser.ci.mjs` (879 specs, 0 failures)
- [x] Manual: Add a component → Ctrl+Z removes it
- [x] Manual: Move a component → Ctrl+Z moves it back
- [x] Manual: Delete a component → Ctrl+Z restores it with connections
- [x] Manual: Rotate a connected component 3 times → Ctrl+Z 3 times restores each rotation
- [x] Manual: Rotate an unconnected component 3 times → Ctrl+Z 3 times restores each rotation
- [x] Manual: Alt+Drag to clone → Ctrl+Z removes the clone (single undo, no leftover move entry)
- [x] Manual: Drag from Component Browser → Ctrl+Z removes it (single undo at drop position)
- [x] Manual: Perform 4+ actions → only last 3 are undoable
- [x] Manual: Import/load a layout → undo buffer is empty
- [x] Manual: Test in read-only mode → Ctrl+Z does nothing