### PR TITLE
Fix bug with positioning new components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ npm start            # starts local dev server
 CI=true npx jasmine-browser-runner runSpecs --config=spec/support/jasmine-browser.ci.mjs
 ```
 
-- ~985 specs, completes in ~6-9 seconds
+- ~991 specs, completes in ~6-9 seconds
 - A WebGL patch is applied during CI for PixiJS v8 headless Chrome support
 
 ## Code style

--- a/spec/support/something.spec.mjs
+++ b/spec/support/something.spec.mjs
@@ -1822,6 +1822,43 @@ describe("LayoutController", function() {
             expect(secondDuplicate).not.toBe(originalComponent);
             expect(secondDuplicate.locked).toBe(false);
         });
+
+        it("positions duplicated group to the right consistently regardless of zoom", function() {
+            let baseplateData = layoutController.trackData.bundles[0].assets.find((a) => a.alias == "baseplate32x32");
+            layoutController.reset();
+
+            layoutController.addComponent(baseplateData);
+            layoutController.addComponent(baseplateData);
+            const comp1 = layoutController.currentLayer.children[0];
+            const comp2 = layoutController.currentLayer.children[1];
+            const group = new ComponentGroup();
+            group.addComponent(comp1);
+            group.addComponent(comp2);
+            LayoutController.selectComponent(group);
+
+            layoutController.workspace.scale.set(0.5);
+            layoutController.duplicateSelectedComponent();
+            const clone05 = LayoutController.selectedComponent;
+            const pos05 = clone05.getPose();
+
+            layoutController.reset();
+            layoutController.addComponent(baseplateData);
+            layoutController.addComponent(baseplateData);
+            const comp3 = layoutController.currentLayer.children[0];
+            const comp4 = layoutController.currentLayer.children[1];
+            const group2 = new ComponentGroup();
+            group2.addComponent(comp3);
+            group2.addComponent(comp4);
+            LayoutController.selectComponent(group2);
+
+            layoutController.workspace.scale.set(1.0);
+            layoutController.duplicateSelectedComponent();
+            const clone10 = LayoutController.selectedComponent;
+            const pos10 = clone10.getPose();
+
+            expect(pos05.x).withContext("x position should be zoom-independent").toBeCloseTo(pos10.x, 0);
+            expect(pos05.y).withContext("y position should be zoom-independent").toBeCloseTo(pos10.y, 0);
+        });
     });
 
     describe("duplicateSelectedComponent", function() {
@@ -4129,39 +4166,41 @@ describe("LayoutController", function() {
             layoutController.config.clearWorkspaceSettings();
         });
 
-        it("computes position for track with connections using first connection vector (custom angle, no snap)", function() {
+        it("centers component with connections at viewport center (custom angle, no snap)", function() {
             layoutController.config.workspaceSnapToSize = 0;
             expect(straightTrackData.connections.length).toBeGreaterThan(0);
-            const fakeReturn = { x: 600.31234, y: 401.98761 }; // intentionally non-rounded
+            const fakeReturn = { x: 600.31234, y: 401.98761, angle: 0 };
             const angle = Math.PI / 5;
+            const screenCenterX = layoutController.app.screen.width / 2;
+            const screenCenterY = layoutController.app.screen.height / 2;
+            const layerCenter = layoutController.currentLayer.toLocal({x: screenCenterX, y: screenCenterY});
             const spy = spyOn(straightTrackData.connections[0].vector, 'getStartPosition').and.returnValue(fakeReturn);
             const pos = layoutController._newComponentPosition(straightTrackData, angle);
-            expect(spy).toHaveBeenCalledOnceWith({ x: 512, y: 384, angle });
-            // fround applied before layer transform
+            expect(spy).toHaveBeenCalledOnceWith({ x: layerCenter.x, y: layerCenter.y, angle });
             expect(pos.x).toBeCloseTo(Math.fround(fakeReturn.x), 6);
             expect(pos.y).toBeCloseTo(Math.fround(fakeReturn.y), 6);
             expect(pos.angle).toBe(angle);
         });
 
-        it("computes position for component without connections (default angle, no snap)", function() {
+        it("centers component without connections at viewport center (default angle, no snap)", function() {
             layoutController.config.workspaceSnapToSize = 0;
             expect(baseplateData.connections || []).toHaveSize(0);
-            // expected raw position before layer transform logic: (150,274) + half width/height
-            const expectedX = 150 + (baseplateData.width / 2);
-            const expectedY = 274 + (baseplateData.height / 2);
-            const pos = layoutController._newComponentPosition(baseplateData); // angle defaults to 0
+            const screenCenterX = layoutController.app.screen.width / 2;
+            const screenCenterY = layoutController.app.screen.height / 2;
+            const layerCenter = layoutController.currentLayer.toLocal({x: screenCenterX, y: screenCenterY});
+            const pos = layoutController._newComponentPosition(baseplateData);
             expect(pos.angle).toBe(0);
-            // After internal toLocal() trick the coordinates should remain the computed values
-            expect(pos.x).toBeCloseTo(expectedX, 6);
-            expect(pos.y).toBeCloseTo(expectedY, 6);
+            expect(pos.x).toBeCloseTo(layerCenter.x, 6);
+            expect(pos.y).toBeCloseTo(layerCenter.y, 6);
         });
 
         it("snaps position to grid for component without connections when snapToGrid enabled", function() {
             layoutController.config.workspaceSnapToSize = 16;
-            const rawX = 150 + (baseplateData.width / 2);
-            const rawY = 274 + (baseplateData.height / 2);
-            const expectedX = Math.round(rawX / 16) * 16;
-            const expectedY = Math.round(rawY / 16) * 16;
+            const screenCenterX = layoutController.app.screen.width / 2;
+            const screenCenterY = layoutController.app.screen.height / 2;
+            const layerCenter = layoutController.currentLayer.toLocal({x: screenCenterX, y: screenCenterY});
+            const expectedX = Math.round(layerCenter.x / 16) * 16;
+            const expectedY = Math.round(layerCenter.y / 16) * 16;
             const pos = layoutController._newComponentPosition(baseplateData);
             expect(pos.x % 16).toBe(0);
             expect(pos.y % 16).toBe(0);
@@ -4169,17 +4208,43 @@ describe("LayoutController", function() {
             expect(pos.y).toBe(expectedY);
         });
 
-        it("snaps position to grid for component with connections when snapToGrid enabled", function() {
+        it("offsets snap by half grid for odd-sized components so edges align to grid", function() {
             layoutController.config.workspaceSnapToSize = 16;
-            const fakeReturn = { x: 593.27, y: 377.61 }; // non multiples of 16 so rounding happens
-            spyOn(straightTrackData.connections[0].vector, 'getStartPosition').and.returnValue(fakeReturn);
+            const oddData = layoutController.trackData.bundles[0].assets.find((a) => a.alias == "pineTreeSmall");
+            expect(oddData).toBeDefined();
+            expect(Math.round(oddData.width / 16) % 2).withContext("pineTreeSmall should be odd grid units wide").toBe(1);
+            const pos = layoutController._newComponentPosition(oddData);
+            expect(pos.x % 16).withContext("center should be at half-grid offset").toBe(8);
+            expect(pos.y % 16).withContext("center should be at half-grid offset").toBe(8);
+            const leftEdge = pos.x - oddData.width / 2;
+            const rightEdge = pos.x + oddData.width / 2;
+            expect(leftEdge % 16).withContext("left edge should align to grid").toBe(0);
+            expect(rightEdge % 16).withContext("right edge should align to grid").toBe(0);
+        });
+
+        it("does not offset snap for even-sized components", function() {
+            layoutController.config.workspaceSnapToSize = 16;
+            const evenData = layoutController.trackData.bundles[0].assets.find((a) => a.alias == "baseplate32x32");
+            expect(evenData).toBeDefined();
+            expect(Math.round(evenData.width / 16) % 2).withContext("baseplate should be even grid units wide").toBe(0);
+            const pos = layoutController._newComponentPosition(evenData);
+            expect(pos.x % 16).withContext("center should be on grid line").toBe(0);
+            expect(pos.y % 16).withContext("center should be on grid line").toBe(0);
+        });
+
+        it("snaps connection position to grid before deriving component center", function() {
+            layoutController.config.workspaceSnapToSize = 16;
+            const screenCenterX = layoutController.app.screen.width / 2;
+            const screenCenterY = layoutController.app.screen.height / 2;
+            const layerCenter = layoutController.currentLayer.toLocal({x: screenCenterX, y: screenCenterY});
+            const snappedX = Math.round(layerCenter.x / 16) * 16;
+            const snappedY = Math.round(layerCenter.y / 16) * 16;
+            const fakeReturn = { x: 593.27, y: 377.61, angle: 0 };
+            const spy = spyOn(straightTrackData.connections[0].vector, 'getStartPosition').and.returnValue(fakeReturn);
             const pos = layoutController._newComponentPosition(straightTrackData, 0);
-            const frx = Math.fround(fakeReturn.x);
-            const fry = Math.fround(fakeReturn.y);
-            expect(pos.x).toBe(Math.round(frx / 16) * 16);
-            expect(pos.y).toBe(Math.round(fry / 16) * 16);
-            expect(pos.x % 16).toBe(0);
-            expect(pos.y % 16).toBe(0);
+            expect(spy).toHaveBeenCalledOnceWith({ x: snappedX, y: snappedY, angle: 0 });
+            expect(pos.x).toBe(Math.fround(fakeReturn.x));
+            expect(pos.y).toBe(Math.fround(fakeReturn.y));
         });
 
         it("preserves provided angle for component without connections", function() {
@@ -4192,6 +4257,62 @@ describe("LayoutController", function() {
         it("uses default angle 0 when none provided", function() {
             const pos = layoutController._newComponentPosition(straightTrackData);
             expect(pos.angle).toBe(0);
+        });
+
+        it("centers component at viewport center when zoomed in", function() {
+            layoutController.config.workspaceSnapToSize = 0;
+            layoutController.workspace.scale.set(1.0);
+            const screenCenterX = layoutController.app.screen.width / 2;
+            const screenCenterY = layoutController.app.screen.height / 2;
+            const layerCenter = layoutController.currentLayer.toLocal({x: screenCenterX, y: screenCenterY});
+            const pos = layoutController._newComponentPosition(baseplateData);
+            expect(pos.x).toBeCloseTo(layerCenter.x, 6);
+            expect(pos.y).toBeCloseTo(layerCenter.y, 6);
+        });
+
+        it("centers component at viewport center when workspace is panned", function() {
+            layoutController.config.workspaceSnapToSize = 0;
+            layoutController.workspace.position.set(100, 50);
+            const screenCenterX = layoutController.app.screen.width / 2;
+            const screenCenterY = layoutController.app.screen.height / 2;
+            const layerCenter = layoutController.currentLayer.toLocal({x: screenCenterX, y: screenCenterY});
+            const pos = layoutController._newComponentPosition(baseplateData);
+            expect(pos.x).toBeCloseTo(layerCenter.x, 6);
+            expect(pos.y).toBeCloseTo(layerCenter.y, 6);
+        });
+
+        it("never places component entirely off-screen at any zoom/pan (property test)", function() {
+            fc.assert(fc.property(
+                fc.double({min: 0.1, max: 5.0, noNaN: true, noDefaultInfinity: true}),
+                fc.double({min: -2000, max: 2000, noNaN: true, noDefaultInfinity: true}),
+                fc.double({min: -2000, max: 2000, noNaN: true, noDefaultInfinity: true}),
+                fc.constantFrom('railStraight9V', 'baseplate32x32'),
+                (zoom, panX, panY, alias) => {
+                    layoutController.reset();
+                    layoutController.config.clearWorkspaceSettings();
+                    layoutController.workspace.scale.set(zoom);
+                    layoutController.workspace.position.set(panX, panY);
+                    layoutController.config.workspaceSnapToSize = 16;
+
+                    const trackData = layoutController.trackData.bundles[0].assets.find(a => a.alias === alias);
+                    const pos = layoutController._newComponentPosition(trackData, 0);
+
+                    const screenX = pos.x * zoom + panX;
+                    const screenY = pos.y * zoom + panY;
+                    const screenWidth = layoutController.app.screen.width;
+                    const screenHeight = layoutController.app.screen.height;
+                    const margin = 1000;
+
+                    expect(screenX).withContext(`screenX for zoom=${zoom}, pan=(${panX},${panY}), alias=${alias}`)
+                        .toBeGreaterThan(-margin);
+                    expect(screenX).withContext(`screenX for zoom=${zoom}, pan=(${panX},${panY}), alias=${alias}`)
+                        .toBeLessThan(screenWidth + margin);
+                    expect(screenY).withContext(`screenY for zoom=${zoom}, pan=(${panX},${panY}), alias=${alias}`)
+                        .toBeGreaterThan(-margin);
+                    expect(screenY).withContext(`screenY for zoom=${zoom}, pan=(${panX},${panY}), alias=${alias}`)
+                        .toBeLessThan(screenHeight + margin);
+                }
+            ), { numRuns: 200 });
         });
     });
 

--- a/src/controller/layoutController.js
+++ b/src/controller/layoutController.js
@@ -1159,33 +1159,33 @@ export class LayoutController {
    * @return {Object} The position and angle for the new component.
    */
   _newComponentPosition(baseData, angle = 0) {
-    /** @type {Pose} */
-    let newPos = { x: 150, y: 274, angle: angle };
-    if (baseData.connections?.length ?? 0 > 0) {
-      newPos = baseData.connections[0].vector.getStartPosition({ x: 512, y: 384, angle: angle });
+    const screenCenter = { x: this.app.screen.width / 2, y: this.app.screen.height / 2 };
+    const layerCenter = this.#currentLayer.toLocal(screenCenter);
+    const snapToSize = this.config.snapToSize;
+
+    if ((baseData.connections?.length ?? 0) > 0) {
+      let connectionPos = { x: layerCenter.x, y: layerCenter.y, angle: angle };
+      if (snapToSize > 0) {
+        connectionPos.x = Math.round(connectionPos.x / snapToSize) * snapToSize;
+        connectionPos.y = Math.round(connectionPos.y / snapToSize) * snapToSize;
+      }
+      let newPos = baseData.connections[0].vector.getStartPosition(connectionPos);
       newPos.x = Math.fround(newPos.x);
       newPos.y = Math.fround(newPos.y);
+      newPos.angle = angle;
+      return newPos;
     } else {
-      // Align to top left corner of component
-      if (baseData.width !== void 0 && baseData.height !== void 0) {
-        newPos.x += baseData.width / 2;
-        newPos.y += baseData.height / 2;
-      } else {
-        /** @type {Texture} */
-        let texture = Assets.get(baseData.alias);
-        if (texture !== void 0) {
-          newPos.x += texture.width / 2;
-          newPos.y += texture.height / 2;
-        }
+      let newPos = { x: layerCenter.x, y: layerCenter.y, angle: angle };
+      if (snapToSize > 0) {
+        const width = baseData.width ?? Assets.get(baseData.alias)?.width ?? 0;
+        const height = baseData.height ?? Assets.get(baseData.alias)?.height ?? 0;
+        const xOffset = (Math.round(width / snapToSize) % 2 === 1) ? snapToSize / 2 : 0;
+        const yOffset = (Math.round(height / snapToSize) % 2 === 1) ? snapToSize / 2 : 0;
+        newPos.x = Math.round((layerCenter.x - xOffset) / snapToSize) * snapToSize + xOffset;
+        newPos.y = Math.round((layerCenter.y - yOffset) / snapToSize) * snapToSize + yOffset;
       }
+      return newPos;
     }
-    newPos = { ...this.#currentLayer.toLocal({x: newPos.x / 2, y: newPos.y / 2}), angle: angle };
-    const snapToSize = this.config.snapToSize;
-    if (snapToSize > 0) {
-      newPos.x = Math.round(newPos.x / snapToSize) * snapToSize;
-      newPos.y = Math.round(newPos.y / snapToSize) * snapToSize;
-    }
-    return newPos;
   }
 
   initCustomComponentUI() {
@@ -1749,10 +1749,7 @@ export class LayoutController {
             continue;
           }
 
-          let offset = 0;
-          if ((selectedTree.width / 16) % 2 === 1) {
-            offset = 8;
-          }
+          const offset = (Math.round(selectedTree.width / snapToSize) % 2 === 1) ? snapToSize / 2 : 0;
           let fits = true;
           for (const existing of placedCircles) {
             const dx = pos.x + offset - existing.x;

--- a/src/model/componentGroup.js
+++ b/src/model/componentGroup.js
@@ -306,9 +306,10 @@ export class ComponentGroup {
         function calculateNextToPosition(component, width) {
           let compWidth;
           if (component instanceof ComponentGroup) {
-            const nextBounds = component.getBounds();
-            let localNextBounds = layer.toLocal({x:nextBounds.minX, y:nextBounds.maxX});
-            compWidth = localNextBounds.y - localNextBounds.x;
+            const gb = component.getBounds();
+            const localMin = layer.toLocal({x: gb.minX, y: gb.minY});
+            const localMax = layer.toLocal({x: gb.maxX, y: gb.maxY});
+            compWidth = localMax.x - localMin.x;
           } else {
             compWidth = component.sprite.width;
           }


### PR DESCRIPTION
Fixes https://bricklayouts.canny.io/feature-requests/p/table-adding-places-new-items-far-away 

When a new component is added without anything selected, the position is calculated using hardcoded magic numbers (150, 274 and 512, 384) that were designed for a specific zoom/position scenario. This results in poor placement at any other zoom level or workspace position. The fix centers new components in the user's viewport instead.

Additionally, there's a zoom-dependent bug when duplicating a group of components with no open connections — the "to the right" offset gets multiplied/divided by the zoom level due to a coordinate space mixup.