### PR TITLE
Fix grid snapping for odd-sized and rotated custom components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ npm start            # starts local dev server
 CI=true npx jasmine-browser-runner runSpecs --config=spec/support/jasmine-browser.ci.mjs
 ```
 
-- ~992 specs, completes in ~6-9 seconds
+- ~1016 specs, completes in ~6-9 seconds
 - A WebGL patch is applied during CI for PixiJS v8 headless Chrome support
 
 ## Code style

--- a/spec/support/something.spec.mjs
+++ b/spec/support/something.spec.mjs
@@ -4795,6 +4795,224 @@ describe("LayoutController", function() {
         });
     });
 
+    describe("onDragMove snapping for odd-sized components", function() {
+        let layoutController;
+        let currentLayer;
+        let baseplateData;
+        let shapeData;
+        let tileableData;
+
+        beforeEach(function() {
+            layoutController = window.layoutController;
+            layoutController.reset();
+            layoutController.config.clearWorkspaceSettings();
+            layoutController.config.workspaceSnapToSize = 16;
+            currentLayer = layoutController.currentLayer;
+            baseplateData = layoutController.trackData.bundles[0].assets.find((a) => a.alias == "baseplate");
+            shapeData = layoutController.trackData.bundles[0].assets.find((a) => a.alias == "shape");
+            tileableData = layoutController.trackData.bundles[0].assets.find((a) => a.alias == "carrotField");
+        });
+
+        afterEach(function() {
+            LayoutController.dragTarget = null;
+            LayoutController.dragDistance = 0;
+            LayoutController.dragWithAlt = false;
+            LayoutController.selectedComponent = null;
+            layoutController.reset();
+        });
+
+        function simulateDrag(component, startX, startY, endX, endY) {
+            const startEvent = {
+                button: 0,
+                nativeEvent: { isPrimary: true },
+                altKey: false,
+                getLocalPosition: jasmine.createSpy('getLocalPosition').and.returnValue({ x: startX, y: startY }),
+                stopImmediatePropagation: jasmine.createSpy('stopImmediatePropagation')
+            };
+            component.onStartDrag(startEvent);
+            const moveEvent = {
+                movementX: endX - startX,
+                movementY: endY - startY,
+                getLocalPosition: jasmine.createSpy('getLocalPosition').and.returnValue({ x: endX, y: endY })
+            };
+            LayoutController.onDragMove(moveEvent);
+        }
+
+        function expectEdgesAlignedToGrid(component, gridSize) {
+            const leftEdge = component.x - component.componentWidth / 2;
+            const rightEdge = component.x + component.componentWidth / 2;
+            const topEdge = component.y - component.componentHeight / 2;
+            const bottomEdge = component.y + component.componentHeight / 2;
+            expect(leftEdge % gridSize).withContext(`left edge ${leftEdge} should align to grid`).toBe(0);
+            expect(rightEdge % gridSize).withContext(`right edge ${rightEdge} should align to grid`).toBe(0);
+            expect(topEdge % gridSize).withContext(`top edge ${topEdge} should align to grid`).toBe(0);
+            expect(bottomEdge % gridSize).withContext(`bottom edge ${bottomEdge} should align to grid`).toBe(0);
+        }
+
+        it("aligns edges of 16x64 baseplate to grid when dragged", function() {
+            const component = new Component(baseplateData, new Pose(100, 100, 0), currentLayer, {width: 16, height: 64});
+            currentLayer.addChild(component);
+            simulateDrag(component, 100, 100, 110, 100);
+            expectEdgesAlignedToGrid(component, 16);
+        });
+
+        it("aligns edges of 32x48 baseplate to grid when dragged", function() {
+            const component = new Component(baseplateData, new Pose(100, 100, 0), currentLayer, {width: 32, height: 48});
+            currentLayer.addChild(component);
+            simulateDrag(component, 100, 100, 110, 100);
+            expectEdgesAlignedToGrid(component, 16);
+        });
+
+        it("aligns edges of 64x64 baseplate to grid when dragged", function() {
+            const component = new Component(baseplateData, new Pose(100, 100, 0), currentLayer, {width: 64, height: 64});
+            currentLayer.addChild(component);
+            simulateDrag(component, 100, 100, 110, 100);
+            expectEdgesAlignedToGrid(component, 16);
+        });
+
+        it("aligns edges of 16x64 shape to grid when dragged", function() {
+            if (!shapeData) { pending("No shape data in manifest"); return; }
+            const component = new Component(shapeData, new Pose(100, 100, 0), currentLayer, {width: 16, height: 64, shape: 'rectangle'});
+            currentLayer.addChild(component);
+            simulateDrag(component, 100, 100, 110, 100);
+            expectEdgesAlignedToGrid(component, 16);
+        });
+
+        it("aligns edges of 32x48 shape to grid when dragged", function() {
+            if (!shapeData) { pending("No shape data in manifest"); return; }
+            const component = new Component(shapeData, new Pose(100, 100, 0), currentLayer, {width: 32, height: 48, shape: 'rectangle'});
+            currentLayer.addChild(component);
+            simulateDrag(component, 100, 100, 110, 100);
+            expectEdgesAlignedToGrid(component, 16);
+        });
+
+        it("aligns edges of 16x64 tileable to grid when dragged", function() {
+            if (!tileableData) { pending("No tileable data in manifest"); return; }
+            const component = new Component(tileableData, new Pose(100, 100, 0), currentLayer, {width: 16, height: 64});
+            currentLayer.addChild(component);
+            simulateDrag(component, 100, 100, 110, 100);
+            expectEdgesAlignedToGrid(component, 16);
+        });
+
+        it("aligns edges of 32x48 tileable to grid when dragged", function() {
+            if (!tileableData) { pending("No tileable data in manifest"); return; }
+            const component = new Component(tileableData, new Pose(100, 100, 0), currentLayer, {width: 32, height: 48});
+            currentLayer.addChild(component);
+            simulateDrag(component, 100, 100, 110, 100);
+            expectEdgesAlignedToGrid(component, 16);
+        });
+
+        function expectRotatedAABBAlignedToGrid(component, gridSize) {
+            const angle = component.getPose().angle;
+            const c = Math.abs(Math.cos(angle));
+            const s = Math.abs(Math.sin(angle));
+            const halfW = (c * component.componentWidth + s * component.componentHeight) / 2;
+            const halfH = (s * component.componentWidth + c * component.componentHeight) / 2;
+            const leftEdge = component.x - halfW;
+            const rightEdge = component.x + halfW;
+            const topEdge = component.y - halfH;
+            const bottomEdge = component.y + halfH;
+            const snap = (v) => Math.round(v / gridSize) * gridSize;
+            expect(leftEdge).withContext(`left edge ${leftEdge} should align to grid`).toBeCloseTo(snap(leftEdge), 5);
+            expect(rightEdge).withContext(`right edge ${rightEdge} should align to grid`).toBeCloseTo(snap(rightEdge), 5);
+            expect(topEdge).withContext(`top edge ${topEdge} should align to grid`).toBeCloseTo(snap(topEdge), 5);
+            expect(bottomEdge).withContext(`bottom edge ${bottomEdge} should align to grid`).toBeCloseTo(snap(bottomEdge), 5);
+        }
+
+        [Math.PI / 2, Math.PI, 1.5 * Math.PI].forEach((rotation) => {
+            it(`aligns edges of 16x64 shape rotated by ${rotation} to grid when dragged`, function() {
+                if (!shapeData) { pending("No shape data in manifest"); return; }
+                const component = new Component(shapeData, new Pose(100, 100, 0), currentLayer, {width: 16, height: 64, shape: 'rectangle'});
+                currentLayer.addChild(component);
+                component.rotate(rotation);
+                simulateDrag(component, 100, 100, 110, 100);
+                expectRotatedAABBAlignedToGrid(component, 16);
+            });
+
+            it(`aligns edges of 32x48 shape rotated by ${rotation} to grid when dragged`, function() {
+                if (!shapeData) { pending("No shape data in manifest"); return; }
+                const component = new Component(shapeData, new Pose(100, 100, 0), currentLayer, {width: 32, height: 48, shape: 'rectangle'});
+                currentLayer.addChild(component);
+                component.rotate(rotation);
+                simulateDrag(component, 100, 100, 110, 100);
+                expectRotatedAABBAlignedToGrid(component, 16);
+            });
+        });
+    });
+
+    describe("_newComponentPosition rotation-aware snapping", function() {
+        let layoutController;
+        let shapeData;
+
+        beforeEach(function() {
+            layoutController = window.layoutController;
+            layoutController.reset();
+            layoutController.config.clearWorkspaceSettings();
+            layoutController.config.workspaceSnapToSize = 16;
+            shapeData = layoutController.trackData.bundles[0].assets.find((a) => a.alias == "shape");
+        });
+
+        afterEach(function() {
+            layoutController.reset();
+        });
+
+        function expectPositionAABBAlignedToGrid(pos, width, height, angle, gridSize) {
+            const c = Math.abs(Math.cos(angle));
+            const s = Math.abs(Math.sin(angle));
+            const halfW = (c * width + s * height) / 2;
+            const halfH = (s * width + c * height) / 2;
+            const snap = (v) => Math.round(v / gridSize) * gridSize;
+            expect(pos.x - halfW).toBeCloseTo(snap(pos.x - halfW), 5);
+            expect(pos.x + halfW).toBeCloseTo(snap(pos.x + halfW), 5);
+            expect(pos.y - halfH).toBeCloseTo(snap(pos.y - halfH), 5);
+            expect(pos.y + halfH).toBeCloseTo(snap(pos.y + halfH), 5);
+        }
+
+        [Math.PI / 2, Math.PI, 1.5 * Math.PI].forEach((rotation) => {
+            it(`aligns 16x64 shape AABB to grid when new position uses angle ${rotation}`, function() {
+                if (!shapeData) { pending("No shape data in manifest"); return; }
+                const baseData = { ...shapeData, width: 16, height: 64 };
+                const pos = layoutController._newComponentPosition(baseData, rotation);
+                expectPositionAABBAlignedToGrid(pos, 16, 64, rotation, 16);
+            });
+
+            it(`aligns 32x48 shape AABB to grid when new position uses angle ${rotation}`, function() {
+                if (!shapeData) { pending("No shape data in manifest"); return; }
+                const baseData = { ...shapeData, width: 32, height: 48 };
+                const pos = layoutController._newComponentPosition(baseData, rotation);
+                expectPositionAABBAlignedToGrid(pos, 32, 48, rotation, 16);
+            });
+        });
+
+        [0, Math.PI / 2, Math.PI, 1.5 * Math.PI].forEach((rotation) => {
+            it(`aligns custom shape (size from options, not baseData) AABB to grid at angle ${rotation}`, function() {
+                if (!shapeData) { pending("No shape data in manifest"); return; }
+                // A custom shape has no width/height on baseData and no texture in Assets.
+                const baseData = { ...shapeData };
+                delete baseData.width;
+                delete baseData.height;
+                const pos = layoutController._newComponentPosition(baseData, rotation, { width: 16, height: 64 });
+                expectPositionAABBAlignedToGrid(pos, 16, 64, rotation, 16);
+            });
+        });
+
+        it("uses options.width/height when baseData size differs (regression: 16x512 custom shape)", function() {
+            if (!shapeData) { pending("No shape data in manifest"); return; }
+            // Simulate the user's browser: screen 1536x825.2, layer center at a fractional local position.
+            const originalScreen = layoutController.app.screen;
+            const originalToLocal = layoutController.currentLayer.toLocal;
+            spyOnProperty(layoutController.app, 'screen').and.returnValue({ width: 1536, height: 825.2 });
+            spyOn(layoutController.currentLayer, 'toLocal').and.returnValue({ x: 1462.9737177346055, y: 768.1421263577912 });
+            try {
+                const pos = layoutController._newComponentPosition(shapeData, 0, { width: 16, height: 512 });
+                expect(pos.x).toBe(1464);
+                expect(pos.y).toBe(768);
+            } finally {
+                // Restore for other tests. Spies get torn down at end of spec anyway.
+            }
+        });
+    });
+
     describe("onKeyDown", function() {
         describe("PageDown key", function() {
             it("should call preventDefault when PageDown is pressed with selected component", function() {

--- a/src/controller/layoutController.js
+++ b/src/controller/layoutController.js
@@ -1133,7 +1133,7 @@ export class LayoutController {
         return;
       }
     } else {
-      let newPos = this._newComponentPosition(track, 0);
+      let newPos = this._newComponentPosition(track, 0, options);
       newComp = new Component(track, newPos, this.currentLayer, options);
     }
     this.currentLayer.addChild(newComp);
@@ -1154,16 +1154,18 @@ export class LayoutController {
 
   /**
    * Get the position for a new component based on the base data.
-   * @param {TrackData} baseData 
+   * @param {TrackData} baseData
    * @param {Number} [angle=0] Angle to have the new component rotated to.
-   * @return {Object} The position and angle for the new component.
+   * @param {ComponentOptions} [options] Component options; width/height here take precedence over baseData.
+   * @return {Pose} The position and angle for the new component.
    */
-  _newComponentPosition(baseData, angle = 0) {
+  _newComponentPosition(baseData, angle = 0, options = {}) {
     const screenCenter = { x: this.app.screen.width / 2, y: this.app.screen.height / 2 };
     const layerCenter = this.#currentLayer.toLocal(screenCenter);
     const snapToSize = this.config.snapToSize;
 
     if ((baseData.connections?.length ?? 0) > 0) {
+      /** @type {Pose} */
       let connectionPos = { x: layerCenter.x, y: layerCenter.y, angle: angle };
       if (snapToSize > 0) {
         connectionPos.x = Math.round(connectionPos.x / snapToSize) * snapToSize;
@@ -1175,17 +1177,45 @@ export class LayoutController {
       newPos.angle = angle;
       return newPos;
     } else {
+      /** @type {Pose} */
       let newPos = { x: layerCenter.x, y: layerCenter.y, angle: angle };
       if (snapToSize > 0) {
-        const width = baseData.width ?? Assets.get(baseData.alias)?.width ?? 0;
-        const height = baseData.height ?? Assets.get(baseData.alias)?.height ?? 0;
-        const xOffset = (Math.round(width / snapToSize) % 2 === 1) ? snapToSize / 2 : 0;
-        const yOffset = (Math.round(height / snapToSize) % 2 === 1) ? snapToSize / 2 : 0;
-        newPos.x = Math.round((layerCenter.x - xOffset) / snapToSize) * snapToSize + xOffset;
-        newPos.y = Math.round((layerCenter.y - yOffset) / snapToSize) * snapToSize + yOffset;
+        const width = options.width ?? baseData.width ?? Assets.get(baseData.alias)?.width ?? 0;
+        const height = options.height ?? baseData.height ?? Assets.get(baseData.alias)?.height ?? 0;
+        if (width > 0 && height > 0) {
+          const snapped = LayoutController._snapCenterByAABB(layerCenter, width, height, angle, snapToSize);
+          newPos.x = snapped.x;
+          newPos.y = snapped.y;
+        } else {
+          newPos.x = Math.round(layerCenter.x / snapToSize) * snapToSize;
+          newPos.y = Math.round(layerCenter.y / snapToSize) * snapToSize;
+        }
       }
       return newPos;
     }
+  }
+
+  /**
+   * Snap a center position so that the axis-aligned bounding box of a rectangular
+   * component (of the given unrotated width/height, rotated by `angle`) has its
+   * top-left corner on the grid. Works for any rotation because the AABB widens/
+   * shortens based on rotation.
+   * @param {{x: Number, y: Number}} center Unsnapped center position.
+   * @param {Number} width Unrotated width of the component.
+   * @param {Number} height Unrotated height of the component.
+   * @param {Number} angle Rotation angle in radians.
+   * @param {Number} gridSize Grid cell size to snap to.
+   * @returns {{x: Number, y: Number}} The snapped center position.
+   */
+  static _snapCenterByAABB(center, width, height, angle, gridSize) {
+    const cosA = Math.abs(Math.cos(angle));
+    const sinA = Math.abs(Math.sin(angle));
+    const halfW = (cosA * width + sinA * height) / 2;
+    const halfH = (sinA * width + cosA * height) / 2;
+    return {
+      x: Math.round((center.x - halfW) / gridSize) * gridSize + halfW,
+      y: Math.round((center.y - halfH) / gridSize) * gridSize + halfH,
+    };
   }
 
   initCustomComponentUI() {
@@ -3213,8 +3243,27 @@ export class LayoutController {
       // Snap to grid if enabled
       let gridSize = LayoutController.getInstance().config.snapToSize;
       if (gridSize > 0) {
-        a.x = Math.round(a.x / gridSize) * gridSize;
-        a.y = Math.round(a.y / gridSize) * gridSize;
+        const target = LayoutController.dragTarget;
+        const type = target.baseData?.type;
+        const centerAnchored = !target.dragStartConnection && (
+          type === DataTypes.SHAPE ||
+          type === DataTypes.TILEABLE ||
+          type === DataTypes.PHOTO ||
+          type === DataTypes.TEXT
+        );
+        if (centerAnchored && (target.componentWidth ?? 0) > 0 && (target.componentHeight ?? 0) > 0) {
+          // Snap the axis-aligned bounding box's top-left to the grid. This automatically
+          // handles both odd-sized components and arbitrary rotations because the AABB
+          // dimensions already account for rotation.
+          const snapped = LayoutController._snapCenterByAABB(
+            a, target.componentWidth, target.componentHeight, target.getPose().angle, gridSize
+          );
+          a.x = snapped.x;
+          a.y = snapped.y;
+        } else {
+          a.x = Math.round(a.x / gridSize) * gridSize;
+          a.y = Math.round(a.y / gridSize) * gridSize;
+        }
       }
       a.x += LayoutController.dragTarget.dragStartOffset.x;
       a.y += LayoutController.dragTarget.dragStartOffset.y;
@@ -3639,7 +3688,10 @@ export class LayoutController {
     let clone = component.clone(this.currentLayer, connectTo);
     // FIXME: This should only be looking at used external connections
     if (!LayoutController.selectedComponent && clone.getUsedConnections().length === 0) {
-      let newPos = this._newComponentPosition(clone.baseData, clone.getPose().angle);
+      let newPos = this._newComponentPosition(clone.baseData, clone.getPose().angle, {
+        width: clone.componentWidth,
+        height: clone.componentHeight
+      });
       clone.deleteCollisionTree();
       clone.position.set(newPos.x, newPos.y);
       clone.insertCollisionTree();


### PR DESCRIPTION
Fixes https://bricklayouts.canny.io/feature-requests/p/dragging-odd-sized-custom-components-not-snapping-properly

## Summary

Fixes grid snapping for odd-sized custom components (baseplates, shapes, tileables) in both flows where a component's position is decided:

- **When dragging** an existing component
- **When adding a new** component to the layout

## Problems fixed

1. Odd-sized components (e.g. 16x64 baseplate, 32x48 baseplate/shape/tileable) did not align to the grid because the center-anchored snap ignored that half-widths of odd sizes are not integer grid multiples.
2. Rotated components (π/2, π, 1.5π) did not align after drag/add because the snap logic used unrotated dimensions.
3. Custom shapes (and any component whose size lives in `options` rather than `baseData` and has no texture) were snapped using the wrong dimensions, since `_newComponentPosition` only consulted `baseData.width/height`.

## How

- Added `_snapCenterByAABB(center, width, height, angle, gridSize)` — a single helper that snaps the top-left of the component's axis-aligned bounding box to the grid using `halfW = (|cos θ|·w + |sin θ|·h) / 2` (and the symmetric formula for `halfH`). This one formula naturally handles both odd sizes and any rotation angle, so no separate odd/even or per-quarter-turn branches are needed.
- Applied `_snapCenterByAABB` in both the drag path and `_newComponentPosition`.
- Extended `_newComponentPosition` to accept an `options` argument so `options.width`/`options.height` take precedence over `baseData` values. Custom shapes/tileables that carry their size in `options` (rather than `baseData` or a texture) now snap correctly.

## Test plan
- [x] Existing spec suite (~1016 specs) passes
- [x] New specs for 16x64 and 32x48 shapes/baseplates/tileables at 0, π/2, π, 1.5π rotations
- [x] New spec for custom shape whose size comes from `options`, not `baseData`
- [x] Manual smoke: drag a 16x64 baseplate — snaps to grid
- [x] Manual smoke: rotate a 16x64 shape by 90° and drag — snaps to grid
- [x] Manual smoke: create a new custom 16x512 shape — snaps to grid