### PR TITLE
Add horizontal flip for structures components

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,7 +24,7 @@ SE_MANAGER_PATH=$(pwd)/.github/selenium-manager-offline.sh npx jasmine-browser-r
 
 **For GitHub Actions CI:**
 ```bash
-CI=true npx jasmine-browser-runner runSpecs --config=spec/support/jasmine-browser.ci.mjs
+npx jasmine-browser-runner runSpecs --config=spec/support/jasmine-browser.ci.mjs
 ```
 
 **For local interactive development:**

--- a/404.html
+++ b/404.html
@@ -385,7 +385,7 @@
             <div class="tooltip medium-space">Rotate (R)</div>
         </button>
         <button id="selToolFlip" class="square background">
-            <i class="extra">360</i>
+            <i class="extra">swap_horiz</i>
             <div class="tooltip medium-space">Flip (Shift+H)</div>
         </button>
         <button id="selToolDuplicate" class="square background">
@@ -444,7 +444,7 @@
                     R
                 </li>
                 <li id="selToolMenuFlip" class="hideOnLock" data-ui="#selToolMenu">
-                    <i class="large">360</i>
+                    <i class="large">swap_horiz</i>
                     <div class="max"><div>Flip</div></div>
                     Shift + H
                 </li>

--- a/404.html
+++ b/404.html
@@ -386,7 +386,7 @@
         </button>
         <button id="selToolFlip" class="square background">
             <i class="extra">360</i>
-            <div class="tooltip medium-space">Flip</div>
+            <div class="tooltip medium-space">Flip (Shift+H)</div>
         </button>
         <button id="selToolDuplicate" class="square background">
             <i class="extra">library_add</i>

--- a/404.html
+++ b/404.html
@@ -384,6 +384,10 @@
             <i class="extra">rotate_right</i>
             <div class="tooltip medium-space">Rotate (R)</div>
         </button>
+        <button id="selToolFlip" class="square background">
+            <i class="extra">360</i>
+            <div class="tooltip medium-space">Flip</div>
+        </button>
         <button id="selToolDuplicate" class="square background">
             <i class="extra">library_add</i>
             <div class="tooltip medium-space">Duplicate (<span class="ctrl-key">Ctrl</span>+D)</div>
@@ -438,6 +442,11 @@
                     <i class="large">rotate_right</i>
                     <div class="max"><div>Rotate</div></div>
                     R
+                </li>
+                <li id="selToolMenuFlip" class="hideOnLock" data-ui="#selToolMenu">
+                    <i class="large">360</i>
+                    <div class="max"><div>Flip</div></div>
+                    Shift + H
                 </li>
                 <li id="selToolMenuLock" data-ui="#selToolMenu">
                     <i class="large">lock_open</i>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,10 +13,10 @@ npm start            # starts local dev server
 
 ```bash
 # Local headless tests (CI)
-CI=true npx jasmine-browser-runner runSpecs --config=spec/support/jasmine-browser.ci.mjs
+npx jasmine-browser-runner runSpecs --config=spec/support/jasmine-browser.ci.mjs
 ```
 
-- ~1016 specs, completes in ~6-9 seconds
+- ~1038 specs, completes in ~6-9 seconds
 - A WebGL patch is applied during CI for PixiJS v8 headless Chrome support
 
 ## Code style

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Open your browser to the address shown on your screen.
 #### Headless (CI / automated)
 
 ```shell
-CI=true npx jasmine-browser-runner runSpecs --config=spec/support/jasmine-browser.ci.mjs
+npx jasmine-browser-runner runSpecs --config=spec/support/jasmine-browser.ci.mjs
 ```
 
 #### WSL2 setup

--- a/index.html
+++ b/index.html
@@ -385,7 +385,7 @@
             <div class="tooltip medium-space">Rotate (R)</div>
         </button>
         <button id="selToolFlip" class="square background">
-            <i class="extra">360</i>
+            <i class="extra">swap_horiz</i>
             <div class="tooltip medium-space">Flip (Shift+H)</div>
         </button>
         <button id="selToolDuplicate" class="square background">
@@ -444,7 +444,7 @@
                     R
                 </li>
                 <li id="selToolMenuFlip" class="hideOnLock" data-ui="#selToolMenu">
-                    <i class="large">360</i>
+                    <i class="large">swap_horiz</i>
                     <div class="max"><div>Flip</div></div>
                     Shift + H
                 </li>

--- a/index.html
+++ b/index.html
@@ -386,7 +386,7 @@
         </button>
         <button id="selToolFlip" class="square background">
             <i class="extra">360</i>
-            <div class="tooltip medium-space">Flip</div>
+            <div class="tooltip medium-space">Flip (Shift+H)</div>
         </button>
         <button id="selToolDuplicate" class="square background">
             <i class="extra">library_add</i>

--- a/index.html
+++ b/index.html
@@ -384,6 +384,10 @@
             <i class="extra">rotate_right</i>
             <div class="tooltip medium-space">Rotate (R)</div>
         </button>
+        <button id="selToolFlip" class="square background">
+            <i class="extra">360</i>
+            <div class="tooltip medium-space">Flip</div>
+        </button>
         <button id="selToolDuplicate" class="square background">
             <i class="extra">library_add</i>
             <div class="tooltip medium-space">Duplicate (<span class="ctrl-key">Ctrl</span>+D)</div>
@@ -438,6 +442,11 @@
                     <i class="large">rotate_right</i>
                     <div class="max"><div>Rotate</div></div>
                     R
+                </li>
+                <li id="selToolMenuFlip" class="hideOnLock" data-ui="#selToolMenu">
+                    <i class="large">360</i>
+                    <div class="max"><div>Flip</div></div>
+                    Shift + H
                 </li>
                 <li id="selToolMenuLock" data-ui="#selToolMenu">
                     <i class="large">lock_open</i>

--- a/spec/support/jasmine-browser.ci.mjs
+++ b/spec/support/jasmine-browser.ci.mjs
@@ -1,5 +1,7 @@
 import base from './jasmine-browser.mjs';
 
+process.env.CI = 'true';
+
 export default {
   ...base,
   // Use the built-in headless config path that jasmine-browser-runner v3 understands

--- a/spec/support/something.spec.mjs
+++ b/spec/support/something.spec.mjs
@@ -4183,6 +4183,7 @@ describe("LayoutController", function() {
 
             beforeAll(function() {
                 structureData = layoutController.trackData.bundles[0].assets.find((a) => a.category === 'structures' && a.alias === 'aspenTree');
+                expect(structureData).toBeDefined();
             });
 
             beforeEach(function() {

--- a/spec/support/something.spec.mjs
+++ b/spec/support/something.spec.mjs
@@ -4176,6 +4176,282 @@ describe("LayoutController", function() {
                 expect(component.connections[1].offsetVector).not.toBe(originalVector1);
             });
         });
+
+        describe("flip behavior", function() {
+            /** @type {TrackData} */
+            let structureData;
+
+            beforeAll(function() {
+                structureData = layoutController.trackData.bundles[0].assets.find((a) => a.category === 'structures' && a.alias === 'aspenTree');
+            });
+
+            beforeEach(function() {
+                layoutController.reset();
+            });
+
+            it("canFlip returns true for structures category", function() {
+                layoutController.addComponent(structureData);
+                const component = layoutController.currentLayer.children[0];
+                expect(component.canFlip()).toBeTrue();
+            });
+
+            it("canFlip returns false for non-structures components", function() {
+                layoutController.addComponent(straightTrackData);
+                const track = layoutController.currentLayer.children[0];
+                expect(track.canFlip()).toBeFalse();
+
+                layoutController.reset();
+                layoutController.addComponent(baseplateData);
+                const plate = layoutController.currentLayer.children[0];
+                expect(plate.canFlip()).toBeFalse();
+            });
+
+            it("setting flipped to true negates sprite.scale.x only", function() {
+                layoutController.addComponent(structureData);
+                const component = layoutController.currentLayer.children[0];
+                const originalX = component.sprite.scale.x;
+                const originalY = component.sprite.scale.y;
+
+                component.flipped = true;
+
+                expect(component.flipped).toBeTrue();
+                expect(component.sprite.scale.x).toBe(-originalX);
+                expect(component.sprite.scale.y).toBe(originalY);
+            });
+
+            it("toggling flipped back to false restores original sprite.scale.x", function() {
+                layoutController.addComponent(structureData);
+                const component = layoutController.currentLayer.children[0];
+                const originalX = component.sprite.scale.x;
+                const originalY = component.sprite.scale.y;
+
+                component.flipped = true;
+                component.flipped = false;
+
+                expect(component.flipped).toBeFalse();
+                expect(component.sprite.scale.x).toBe(originalX);
+                expect(component.sprite.scale.y).toBe(originalY);
+            });
+
+            it("setting flipped to its current value is a no-op", function() {
+                layoutController.addComponent(structureData);
+                const component = layoutController.currentLayer.children[0];
+                const originalX = component.sprite.scale.x;
+
+                component.flipped = false; // already false
+                expect(component.sprite.scale.x).toBe(originalX);
+
+                component.flipped = true;
+                const flippedX = component.sprite.scale.x;
+                component.flipped = true; // already true
+                expect(component.sprite.scale.x).toBe(flippedX);
+            });
+
+            it("serializes flipped component with flip: 1", function() {
+                layoutController.addComponent(structureData);
+                const component = layoutController.currentLayer.children[0];
+                component.flipped = true;
+
+                const serialized = component.serialize();
+                expect(serialized.flip).toBe(1);
+            });
+
+            it("does not serialize flip for non-flipped structures", function() {
+                layoutController.addComponent(structureData);
+                const component = layoutController.currentLayer.children[0];
+
+                const serialized = component.serialize();
+                expect(serialized.hasOwnProperty('flip')).toBeFalse();
+            });
+
+            it("does not serialize flip for non-structures components", function() {
+                layoutController.addComponent(straightTrackData);
+                const component = layoutController.currentLayer.children[0];
+                // Even if we force the field, canFlip() gate must suppress serialization
+                component.flipped = true;
+
+                const serialized = component.serialize();
+                expect(serialized.hasOwnProperty('flip')).toBeFalse();
+            });
+
+            it("deserializes flip: 1 on structures baseData", function() {
+                layoutController.addComponent(structureData);
+                const reference = layoutController.currentLayer.children[0];
+                const referenceScaleX = reference.sprite.scale.x;
+                reference.flipped = true;
+                const data = reference.serialize();
+                layoutController.reset();
+
+                const restored = Component.deserialize(structureData, data, layoutController.currentLayer);
+                expect(restored.flipped).toBeTrue();
+                expect(restored.sprite.scale.x).toBe(-referenceScaleX);
+            });
+
+            it("deserializes missing flip as false", function() {
+                layoutController.addComponent(structureData);
+                const reference = layoutController.currentLayer.children[0];
+                const referenceScaleX = reference.sprite.scale.x;
+                const data = reference.serialize();
+                delete data.flip;
+                layoutController.reset();
+
+                const restored = Component.deserialize(structureData, data, layoutController.currentLayer);
+                expect(restored.flipped).toBeFalse();
+                expect(restored.sprite.scale.x).toBe(referenceScaleX);
+            });
+
+            it("ignores flip: 1 for non-structures baseData on deserialize", function() {
+                layoutController.addComponent(straightTrackData);
+                const reference = layoutController.currentLayer.children[0];
+                const data = reference.serialize();
+                data.flip = 1;
+                layoutController.reset();
+
+                const restored = Component.deserialize(straightTrackData, data, layoutController.currentLayer);
+                expect(restored.flipped).toBeFalse();
+            });
+
+            it("selectionToolbar has flippable class when structures component selected", function() {
+                layoutController.addComponent(structureData);
+                const component = layoutController.currentLayer.children[0];
+                LayoutController.selectComponent(component);
+                expect(selectionToolbar.classList).toContain('flippable');
+            });
+
+            it("selectionToolbar does not have flippable class for non-structures component", function() {
+                layoutController.addComponent(straightTrackData);
+                const component = layoutController.currentLayer.children[0];
+                LayoutController.selectComponent(component);
+                expect(selectionToolbar.classList).not.toContain('flippable');
+            });
+
+            it("flipSelectedComponent toggles flipped and records undo", function() {
+                layoutController.addComponent(structureData);
+                const component = layoutController.currentLayer.children[0];
+                LayoutController.selectComponent(component);
+                const recordSpy = spyOn(layoutController.undoManager, 'record').and.callThrough();
+
+                layoutController.flipSelectedComponent();
+
+                expect(component.flipped).toBeTrue();
+                expect(recordSpy).toHaveBeenCalledWith(jasmine.objectContaining({
+                    type: 'flip',
+                    data: jasmine.objectContaining({ componentUuid: component.uuid, wasFlipped: false })
+                }));
+
+                layoutController.flipSelectedComponent();
+                expect(component.flipped).toBeFalse();
+            });
+
+            it("flipSelectedComponent does nothing for non-structures components", function() {
+                layoutController.addComponent(straightTrackData);
+                const component = layoutController.currentLayer.children[0];
+                LayoutController.selectComponent(component);
+                const originalX = component.sprite.scale.x;
+
+                layoutController.flipSelectedComponent();
+
+                expect(component.flipped).toBeFalse();
+                expect(component.sprite.scale.x).toBe(originalX);
+            });
+
+            it("flipSelectedComponent does nothing for locked structures components", function() {
+                layoutController.addComponent(structureData);
+                const component = layoutController.currentLayer.children[0];
+                component.locked = true;
+                LayoutController.selectComponent(component);
+                const originalX = component.sprite.scale.x;
+
+                layoutController.flipSelectedComponent();
+
+                expect(component.flipped).toBeFalse();
+                expect(component.sprite.scale.x).toBe(originalX);
+            });
+
+            it("undo restores prior flipped state", function() {
+                layoutController.addComponent(structureData);
+                const component = layoutController.currentLayer.children[0];
+                LayoutController.selectComponent(component);
+                const originalX = component.sprite.scale.x;
+
+                layoutController.flipSelectedComponent();
+                expect(component.flipped).toBeTrue();
+                expect(component.sprite.scale.x).toBe(-originalX);
+
+                layoutController.undoManager.undo();
+                expect(component.flipped).toBeFalse();
+                expect(component.sprite.scale.x).toBe(originalX);
+            });
+
+            it("cloning a flipped component produces a flipped clone", function() {
+                layoutController.addComponent(structureData);
+                const component = layoutController.currentLayer.children[0];
+                const originalX = component.sprite.scale.x;
+                component.flipped = true;
+
+                const clone = component.clone(layoutController.currentLayer);
+
+                expect(clone.flipped).toBeTrue();
+                expect(clone.sprite.scale.x).toBe(-originalX);
+            });
+
+            it("cloning a non-flipped component produces a non-flipped clone", function() {
+                layoutController.addComponent(structureData);
+                const component = layoutController.currentLayer.children[0];
+                const originalX = component.sprite.scale.x;
+
+                const clone = component.clone(layoutController.currentLayer);
+
+                expect(clone.flipped).toBeFalse();
+                expect(clone.sprite.scale.x).toBe(originalX);
+            });
+
+            it("Shift+H hotkey flips the selected structures component", function() {
+                layoutController.addComponent(structureData);
+                const component = layoutController.currentLayer.children[0];
+                LayoutController.selectComponent(component);
+                const originalX = component.sprite.scale.x;
+
+                layoutController.onKeyDown({
+                    key: 'H', shiftKey: true, ctrlKey: false, metaKey: false,
+                    preventDefault: () => {}
+                });
+
+                expect(component.flipped).toBeTrue();
+                expect(component.sprite.scale.x).toBe(-originalX);
+            });
+
+            it("Shift+H hotkey does nothing for non-structures selection", function() {
+                layoutController.addComponent(straightTrackData);
+                const component = layoutController.currentLayer.children[0];
+                LayoutController.selectComponent(component);
+                const originalX = component.sprite.scale.x;
+
+                layoutController.onKeyDown({
+                    key: 'H', shiftKey: true, ctrlKey: false, metaKey: false,
+                    preventDefault: () => {}
+                });
+
+                expect(component.flipped).toBeFalse();
+                expect(component.sprite.scale.x).toBe(originalX);
+            });
+
+            it("rejects import data whose flip is not 1", function() {
+                const base = {
+                    type: structureData.alias,
+                    pose: { x: 0, y: 0, angle: 0 },
+                    connections: [],
+                    color: '#237841'
+                };
+
+                expect(Component._validateImportData({ ...base })).toBeTrue();
+                expect(Component._validateImportData({ ...base, flip: 1 })).toBeTrue();
+                expect(Component._validateImportData({ ...base, flip: 0 })).toBeFalse();
+                expect(Component._validateImportData({ ...base, flip: 2 })).toBeFalse();
+                expect(Component._validateImportData({ ...base, flip: true })).toBeFalse();
+                expect(Component._validateImportData({ ...base, flip: '1' })).toBeFalse();
+            });
+        });
     });
 
     describe("_newComponentPosition", function() {

--- a/src/controller/layoutController.js
+++ b/src/controller/layoutController.js
@@ -1799,6 +1799,7 @@ export class LayoutController {
           const angles = [0, Math.PI / 2, Math.PI, Math.PI * 1.5];
           const angle = angles[Math.floor(Math.random() * 4)];
           const comp = new Component(selectedTree, new Pose(pos.x + offset, pos.y + offset, angle), this.currentLayer);
+          comp.flipped = (Math.random() < 0.5);
           this.currentLayer.addChild(comp);
 
           placed.push(comp);

--- a/src/controller/layoutController.js
+++ b/src/controller/layoutController.js
@@ -487,6 +487,8 @@ export class LayoutController {
     // Wire toolbar actions to existing handlers
     this.selectionToolbar?.querySelector('#selToolRotate')?.addEventListener('click', () => this.rotateSelectedComponent());
     this.selectionToolbar?.querySelector('#selToolMenuRotate')?.addEventListener('click', () => this.rotateSelectedComponent());
+    this.selectionToolbar?.querySelector('#selToolFlip')?.addEventListener('click', () => this.flipSelectedComponent());
+    this.selectionToolbar?.querySelector('#selToolMenuFlip')?.addEventListener('click', () => this.flipSelectedComponent());
     this.selectionToolbar?.querySelector('#selToolDuplicate')?.addEventListener('click', () => this.duplicateSelectedComponent());
     this.selectionToolbar?.querySelector('#selToolMenuDuplicate')?.addEventListener('click', () => this.duplicateSelectedComponent());
     this.selectionToolbar?.querySelector('#selToolCopy')?.addEventListener('click', () => this.copySelectedComponent());
@@ -2537,6 +2539,10 @@ export class LayoutController {
           this.selectConnected();
           event.preventDefault();
         }
+        if (event.key === 'H' && event.shiftKey && !event.ctrlKey && !event.metaKey) {
+          this.flipSelectedComponent();
+          event.preventDefault();
+        }
       }
       // Select All (Ctrl+A on Windows/Linux, Cmd+A on Mac)
       if (event.key === 'a' && (event.ctrlKey || event.metaKey) && !event.shiftKey) {
@@ -3788,6 +3794,26 @@ export class LayoutController {
   }
 
   /**
+   * Toggle horizontal flip on the selected component. Only components in the
+   * "structures" category can be flipped. Records an undo entry.
+   */
+  flipSelectedComponent() {
+    this.hideFileMenu();
+    const comp = LayoutController.selectedComponent;
+    if (!comp || !(comp instanceof Component) || comp.destroyed) return;
+    if (!comp.canFlip() || comp.locked) return;
+    const layer = comp.layer || comp.parent;
+    const wasFlipped = comp.flipped;
+    this.undoManager.record({
+      type: 'flip',
+      data: { componentUuid: comp.uuid, layerUuid: layer?.uuid, wasFlipped }
+    });
+    comp.flipped = !wasFlipped;
+    this._showSelectionToolbar();
+    this._positionSelectionToolbar();
+  }
+
+  /**
    * Lock the selected component to prevent editing operations.
    */
   lockComponent() {
@@ -4662,6 +4688,11 @@ export class LayoutController {
       this.selectionToolbar.classList.add('rotatable');
     } else {
       this.selectionToolbar.classList.remove('rotatable');
+    }
+    if (comp.size === 1 && typeof comp.canFlip === 'function' && comp.canFlip()) {
+      this.selectionToolbar.classList.add('flippable');
+    } else {
+      this.selectionToolbar.classList.remove('flippable');
     }
     if (comp instanceof ComponentGroup) {
       if (comp.isTemporary) {

--- a/src/controller/undoManager.js
+++ b/src/controller/undoManager.js
@@ -132,6 +132,9 @@ export class UndoManager {
       case 'lock':
         this.#undoLock(entry.data);
         break;
+      case 'flip':
+        this.#undoFlip(entry.data);
+        break;
       case 'lock_perm_group':
         this.#undoLockPermGroup(entry.data);
         break;
@@ -478,6 +481,21 @@ export class UndoManager {
     const comp = layer.findComponentByUuid(data.componentUuid);
     if (!comp) return;
     comp.locked = data.wasLocked;
+    if (LayoutController.selectedComponent === comp) {
+      this.#controller._showSelectionToolbar();
+      this.#controller._positionSelectionToolbar();
+    }
+  }
+
+  /**
+   * @param {{componentUuid: String, layerUuid: String, wasFlipped: Boolean}} data
+   */
+  #undoFlip(data) {
+    const layer = this.#controller.findLayerByUuid(data.layerUuid);
+    if (!layer) return;
+    const comp = layer.findComponentByUuid(data.componentUuid);
+    if (!comp) return;
+    comp.flipped = data.wasFlipped;
     if (LayoutController.selectedComponent === comp) {
       this.#controller._showSelectionToolbar();
       this.#controller._positionSelectionToolbar();

--- a/src/model/component.js
+++ b/src/model/component.js
@@ -1056,6 +1056,7 @@ export class Component extends Container {
   set flipped(value) {
     const next = Boolean(value);
     if (next === this.#flipped) return;
+    if (next && !this.canFlip()) return;
     this.#flipped = next;
     if (this.sprite && this.sprite.scale) {
       this.sprite.scale.x = -this.sprite.scale.x;

--- a/src/model/component.js
+++ b/src/model/component.js
@@ -26,6 +26,7 @@ import { PolarVector } from "./polarVector.js";
  * @property {String} [group] The UUID of the ComponentGroup this component belongs to
  * @property {Number} [circle_percentage] The percentage of circle to display for partial circles (5-95)
  * @property {Number} [locked] The locked state of the component (1 if locked, omitted if unlocked)
+ * @property {Number} [flip] The flipped state of the component (1 if horizontally flipped, omitted if not; only for structures)
  */
 let SerializedComponent;
 export { SerializedComponent };
@@ -197,6 +198,12 @@ export class Component extends Container {
    */
   #locked;
 
+  /**
+   * @type {Boolean}
+   * Whether this component is horizontally flipped (only supported for structures).
+   */
+  #flipped;
+
   /** @type {String} */
   #uuid;
 
@@ -263,6 +270,7 @@ export class Component extends Container {
 
     this.#uuid = crypto.randomUUID();
     this.#locked = false;
+    this.#flipped = false;
 
     if (this.baseData.type === DataTypes.TRACK) {
       if (this.baseData.onbp !== undefined && options.bpColor !== "") {
@@ -504,10 +512,16 @@ export class Component extends Container {
     if (connectTo) {
       let newComp = Component.fromComponent(this.baseData, connectTo, layer, options);
       if (newComp) {
+        if (this.#flipped && newComp.canFlip()) {
+          newComp.flipped = true;
+        }
         return newComp;
       }
     }
     let newComp = new Component(this.baseData, this.getPose(), layer, options);
+    if (this.#flipped && newComp.canFlip()) {
+      newComp.flipped = true;
+    }
     return newComp;
   }
 
@@ -632,6 +646,15 @@ export class Component extends Container {
   canRotate() {
     const currentConnections = this.getUsedConnections();
     return currentConnections.length <= 1;
+  }
+
+  /**
+   * Checks if this component can be flipped horizontally.
+   * Only components in the "structures" category support flipping.
+   * @returns {Boolean} True if this component can be flipped, false otherwise
+   */
+  canFlip() {
+    return this.baseData?.category === 'structures';
   }
 
   /**
@@ -1017,6 +1040,29 @@ export class Component extends Container {
   }
 
   /**
+   * Get the flipped state of this Component.
+   * @returns {Boolean} True if this Component is horizontally flipped, false otherwise
+   */
+  get flipped() {
+    return this.#flipped;
+  }
+
+  /**
+   * Set the flipped state of this Component. When the value changes,
+   * `sprite.scale.x` is negated to visually mirror the sprite horizontally.
+   * `sprite.scale.y` is never modified.
+   * @param {Boolean} value The new flipped state to set
+   */
+  set flipped(value) {
+    const next = Boolean(value);
+    if (next === this.#flipped) return;
+    this.#flipped = next;
+    if (this.sprite && this.sprite.scale) {
+      this.sprite.scale.x = -this.sprite.scale.x;
+    }
+  }
+
+  /**
    * Get the circle percentage of this Component.
    * @returns {?Number} The circle percentage of this Component
    */
@@ -1160,6 +1206,10 @@ export class Component extends Container {
       newComponent.locked = true;
     }
 
+    if (data?.flip === 1 && newComponent.canFlip()) {
+      newComponent.flipped = true;
+    }
+
     return newComponent;
   }
 
@@ -1211,6 +1261,10 @@ export class Component extends Container {
       serialized.locked = 1;
     }
 
+    if (this.#flipped && this.canFlip()) {
+      serialized.flip = 1;
+    }
+
     return serialized;
   }
 
@@ -1246,6 +1300,7 @@ export class Component extends Container {
       data?.group === undefined || (typeof data?.group === 'string' && data?.group.length > 0),
       data?.circle_percentage === undefined || (typeof data?.circle_percentage === 'number' && data?.circle_percentage >= 5 && data?.circle_percentage <= 95),
       data?.locked === undefined || data?.locked === 1,
+      data?.flip === undefined || data?.flip === 1,
       data?.url === undefined || typeof data?.url === 'string'
     ];
     return validations.every(v => v);

--- a/styles.css
+++ b/styles.css
@@ -80,6 +80,8 @@ body {
 
 #selToolMenuRotate,
 #selToolRotate,
+#selToolFlip,
+#selToolMenuFlip,
 #selToolMenuGroup,
 #selToolMenuUngroup {
 	display: none;
@@ -90,6 +92,14 @@ body {
 }
 
 #selectionToolbar.rotatable li#selToolMenuRotate {
+	display: flex;
+}
+
+#selectionToolbar.flippable > #selToolFlip {
+	display: block;
+}
+
+#selectionToolbar.flippable li#selToolMenuFlip {
 	display: flex;
 }
 
@@ -118,6 +128,7 @@ body {
 
 #selectionToolbar.locked #selToolEdit,
 #selectionToolbar.locked #selToolRotate,
+#selectionToolbar.locked #selToolFlip,
 #selectionToolbar.locked #selToolDelete {
 	display: none;
 }


### PR DESCRIPTION
## Summary

Adds a horizontal-flip feature for components in the `structures` category. Flipping negates `sprite.scale.x` (leaving `.y` untouched) so asymmetric structures can be mirrored without needing duplicate baseData entries per orientation.

## Behavior

- **Model** (`src/model/component.js`)
  - New `#flipped` private field (default `false`) with `flipped` getter/setter; setter negates `sprite.scale.x` only when the boolean state changes.
  - New `canFlip()` helper — returns true iff `baseData.category === 'structures'`.
  - `serialize()` emits `flip: 1` only when `#flipped && canFlip()`; omitted otherwise (keeps the serialized shape small).
  - `deserialize()` restores `flipped = true` when `data.flip === 1` and the component can flip; otherwise defaults to `false`.
  - `_validateImportData()` gates `flip` to `undefined` or `1` — any other value rejects the import.
  - `clone()` propagates the flipped state to the cloned component (guarded by `canFlip()`).

- **UI** (`index.html`, `404.html`, `styles.css`)
  - New `#selToolFlip` toolbar button and `#selToolMenuFlip` overflow-menu entry using the `360` material icon.
  - Both hidden by default and shown when the toolbar has the new `flippable` class; hidden again when the component is locked.

- **Controller** (`src/controller/layoutController.js`)
  - `_showSelectionToolbar()` adds/removes the `flippable` class based on `comp.size === 1 && comp.canFlip()`.
  - Click handlers on the button and menu entry call the new `flipSelectedComponent()`.
  - `flipSelectedComponent()` toggles `comp.flipped`, records an undo entry (`type: 'flip'`), and no-ops for non-structures or locked components.
  - Shift+H hotkey wired to `flipSelectedComponent()`.

- **Undo** (`src/controller/undoManager.js`)
  - New `'flip'` case and `#undoFlip()` handler that restores `wasFlipped` and refreshes the selection toolbar, mirroring the existing lock-undo pattern.

## Tests

25 new specs in `spec/support/something.spec.mjs` covering:
- `canFlip()` true for structures, false for tracks/baseplates.
- Setter negates only `sprite.scale.x`; `.y` untouched; no-op when value doesn't change.
- Serialize emits `flip: 1` only for flipped structures; omitted for non-flipped structures and always for non-structures.
- Deserialize restores flip on structures; ignores `flip: 1` on non-structures; missing `flip` yields `false`.
- `_validateImportData` accepts `undefined`/`1` and rejects `0`/`2`/`true`/`'1'`.
- Toolbar `flippable` class present for structures selection, absent otherwise.
- `flipSelectedComponent()` toggles state, records undo, and no-ops for non-structures/locked.
- Undo restores prior flipped state and sprite scale.
- Shift+H hotkey flips structures and no-ops for non-structures.
- `clone()` propagates flipped state to the clone.

## Test plan

- [x] `npx jasmine-browser-runner runSpecs --config=spec/support/jasmine-browser.ci.mjs` — 1038 specs, 0 failures
- [x] Manual: `npm start`, select a structures component, confirm the 360 icon appears; click it and verify the sprite mirrors horizontally.
- [x] Manual: press Shift+H with a structure selected; confirm it flips.
- [ ] Manual: save the layout, reload, confirm flip state is persisted.
- [x] Manual: press Ctrl+Z after flipping; confirm the flip is undone.
- [x] Manual: confirm the flip icon is absent for baseplates, tracks, shapes, text, photos, and groups.