### PR TITLE
Fix mobile rotate button rotating opposite direction

### DIFF
--- a/src/controller/layoutController.js
+++ b/src/controller/layoutController.js
@@ -424,7 +424,7 @@ export class LayoutController {
       this.searchElement.classList.remove('hasInput');
       this.createComponentBrowser();
     });
-    document.getElementById('buttonRotate').addEventListener('click', this.rotateSelectedComponent.bind(this));
+    document.getElementById('buttonRotate').addEventListener('click', () => this.rotateSelectedComponent());
     document.getElementById('buttonRemove').addEventListener('click', this.deleteSelectedComponent.bind(this));
     document.getElementById('buttonDownload').addEventListener('click', this.downloadLayout.bind(this));
     document.getElementById('buttonImport').addEventListener('click', this.onImportClick.bind(this));


### PR DESCRIPTION
## Summary
- On mobile, tapping `#buttonRotate` rotated counter-clockwise while the selection toolbar's `#selToolRotate` rotated clockwise. Both should rotate clockwise.
- Root cause: `buttonRotate` was bound via `.bind(this)`, so the click `Event` object was passed as the first argument to `rotateSelectedComponent(left = false)`. Since the Event is truthy, `left` evaluated to true and rotation went counter-clockwise.
- Fix: wrap in an arrow function so no argument is passed, matching how `#selToolRotate` is wired.

Bug report: https://bricklayouts.canny.io/feature-requests/p/mobile-rotate-button-is-opposite-of-toolbar

## Test plan
- [x] Full spec suite passes (1038 specs, 0 failures)
- [x] Verify on mobile that tapping the toolbar rotate button rotates clockwise
- [x] Verify the selection toolbar rotate still rotates clockwise